### PR TITLE
Install Rust toolchain when source installing on windows allways

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -32,6 +32,4 @@ clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) rust/target
 
 rustup:
-	if [ "${GITHUB_ACTIONS}" = "true" ]; then \
-		rustup toolchain install stable-gnu || true; \
-	fi
+	rustup toolchain install stable-gnu || true


### PR DESCRIPTION
In #5 I made a change to configure the toolchain in Windows on GitHub Actions, but found that this is ignored by the R-universe builder.
https://github.com/r-universe-org/build-and-check/blob/9abc4b490a8371d548f93a86ca653ef4cf79b1c5/action.yml#L111