### PR TITLE
Update example of using with tidyquery

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ on:
       - R/**
       - src/**
       - tests/**
-      - vignetts/*
+      - vignettes/*
       - DESCRIPTION
       - NAMESPACE
   pull_request:
@@ -19,7 +19,7 @@ on:
       - R/**
       - src/**
       - tests/**
-      - vignetts/*
+      - vignettes/*
       - DESCRIPTION
       - NAMESPACE
   workflow_dispatch:

--- a/vignettes/prqlr.Rmd
+++ b/vignettes/prqlr.Rmd
@@ -89,7 +89,7 @@ derive [mpg_int = round 0 mpg]
 
 Using it with the `{tidyquery}` package, we can execute PRQL queries against R `?data.frame`.
 
-Let's run a query that aggregates a data.frame `flights`,
+Let's run a query that joins and aggregates two data.frames, `flights` and `planes`,
 contained in the `{nycflights13}` package.
 
 ```{r}
@@ -98,15 +98,17 @@ library(nycflights13)
 
 "
 from flights
+join side:left planes [==tailnum]
 filter (distance | in 200..300)
 filter air_time != null
 group [origin, dest] (
   aggregate [
     num_flts = count,
+    num_seats = (sum seats | round 0),
     avg_delay = (average arr_delay | round 0)
   ]
 )
-sort avg_delay
+sort [-num_seats, avg_delay]
 take 2
 " |>
   prql_to_sql() |>
@@ -121,6 +123,7 @@ library(dplyr, warn.conflicts = FALSE)
 library(nycflights13)
 
 flights |>
+  left_join(planes, by = "tailnum") |>
   filter(
     distance |> between(200, 300),
     !is.na(air_time)
@@ -128,9 +131,10 @@ flights |>
   group_by(origin, dest) |>
   summarise(
     num_flts = n(),
+    num_seats = sum(seats, na.rm = TRUE) |> round(0),
     avg_delay = mean(arr_delay, na.rm = TRUE) |> round(0),
     .groups = "drop"
   ) |>
-  arrange(avg_delay) |>
+  arrange(desc(num_seats), avg_delay) |>
   head(2)
 ```


### PR DESCRIPTION
I simplified the query example using tidyquery in #16, but will revert to something closer to what it was before.
The difference from the previous one is the deletion of `filter num_flts > 3000`, that makes it incompatible with tidyquery because it uses the WITH clause.

```r
library(tidyquery)
library(nycflights13)

"
from flights
join side:left planes [tailnum]
filter (distance | in 200..300)
filter air_time != null
group [origin, dest] (
  aggregate [
    num_flts = count,
    num_seats = (sum seats | round 0),
    avg_delay = (average arr_delay | round 0)
  ]
)
filter num_flts > 3000
sort [-num_seats, avg_delay]
take 2
" |>
  prql_to_sql() |>
  query()
```