### PR TITLE
Update the `Makevars` files not to write files in user's HOME directory

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -7,12 +7,19 @@ all: C_clean
 
 $(SHLIB): $(STATLIB)
 
+CARGOTMP = $(PWD)/.cargo
+
 $(STATLIB):
 	# In some environments, ~/.cargo/bin might not be included in PATH, so we need
 	# to set it here to ensure cargo can be invoked. It is appended to PATH and
 	# therefore is only used if cargo is absent from the user's PATH.
+	if [ "${NOT_CRAN}" != "true" ]; then \
+		CARGO_HOME=$(CARGOTMP); \
+	fi && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	rm -Rf $(CARGOTMP)
+	rm -Rf $(LIBDIR)/build
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/src/Makevars
+++ b/src/Makevars
@@ -7,13 +7,14 @@ all: C_clean
 
 $(SHLIB): $(STATLIB)
 
-CARGOTMP = $(PWD)/.cargo
+NOT_CRAN := $(shell echo "$(NOT_CRAN)" | tr '[:upper:]' '[:lower:]')
+CARGOTMP := $(PWD)/.cargo
 
 $(STATLIB):
 	# In some environments, ~/.cargo/bin might not be included in PATH, so we need
 	# to set it here to ensure cargo can be invoked. It is appended to PATH and
 	# therefore is only used if cargo is absent from the user's PATH.
-	if [ "${NOT_CRAN}" != "true" ]; then \
+	if [ "$(NOT_CRAN)" != "true" ]; then \
 		CARGO_HOME=$(CARGOTMP); \
 	fi && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \

--- a/src/Makevars
+++ b/src/Makevars
@@ -7,14 +7,13 @@ all: C_clean
 
 $(SHLIB): $(STATLIB)
 
-NOT_CRAN := $(shell echo "$(NOT_CRAN)" | tr '[:upper:]' '[:lower:]')
-CARGOTMP := $(PWD)/.cargo
+CARGOTMP = $(PWD)/.cargo
 
 $(STATLIB):
 	# In some environments, ~/.cargo/bin might not be included in PATH, so we need
 	# to set it here to ensure cargo can be invoked. It is appended to PATH and
 	# therefore is only used if cargo is absent from the user's PATH.
-	if [ "$(NOT_CRAN)" != "true" ]; then \
+	if [ "$(NOT_CRAN)" != "true" ] && [ "$(NOT_CRAN)" != "TRUE" ]; then \
 		CARGO_HOME=$(CARGOTMP); \
 	fi && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -12,8 +12,7 @@ all: C_clean
 
 $(SHLIB): $(STATLIB)
 
-NOT_CRAN := $(shell echo "$(NOT_CRAN)" | tr '[:upper:]' '[:lower:]')
-CARGOTMP := $(PWD)/.cargo
+CARGOTMP = $(PWD)/.cargo
 
 $(STATLIB):
 	mkdir -p $(TARGET_DIR)/libgcc_mock
@@ -24,7 +23,7 @@ $(STATLIB):
 		cp libgcc_eh.a libgcc_s.a
 
 	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
-	if [ "$(NOT_CRAN)" != "true" ]; then \
+	if [ "$(NOT_CRAN)" != "true" ] && [ "$(NOT_CRAN)" != "TRUE" ]; then \
 		CARGO_HOME=$(CARGOTMP); \
 	fi && \
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -12,7 +12,8 @@ all: C_clean
 
 $(SHLIB): $(STATLIB)
 
-CARGOTMP = $(PWD)/.cargo
+NOT_CRAN := $(shell echo "$(NOT_CRAN)" | tr '[:upper:]' '[:lower:]')
+CARGOTMP := $(PWD)/.cargo
 
 $(STATLIB):
 	mkdir -p $(TARGET_DIR)/libgcc_mock
@@ -23,7 +24,7 @@ $(STATLIB):
 		cp libgcc_eh.a libgcc_s.a
 
 	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
-	if [ "${NOT_CRAN}" != "true" ]; then \
+	if [ "$(NOT_CRAN)" != "true" ]; then \
 		CARGO_HOME=$(CARGOTMP); \
 	fi && \
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -12,6 +12,8 @@ all: C_clean
 
 $(SHLIB): $(STATLIB)
 
+CARGOTMP = $(PWD)/.cargo
+
 $(STATLIB):
 	mkdir -p $(TARGET_DIR)/libgcc_mock
 	cd $(TARGET_DIR)/libgcc_mock && \
@@ -21,9 +23,14 @@ $(STATLIB):
 		cp libgcc_eh.a libgcc_s.a
 
 	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
+	if [ "${NOT_CRAN}" != "true" ]; then \
+		CARGO_HOME=$(CARGOTMP); \
+	fi && \
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
 		cargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
+	rm -Rf $(CARGOTMP)
+	rm -Rf $(LIBDIR)/build
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)


### PR DESCRIPTION
See <https://github.com/r-rust/faq>.

> ## How to avoid writing in HOME
>
> CRAN has a policy:
>
>> packages should not write in the user’s home filespace (including clipboards), nor anywhere else on the file system apart from the R session’s temporary directory
>
> On most systems, the default cargo configuration keeps a cache in `~/.cargo`, which can be changed by setting the `CARGO_HOME` envvar when invoking cargo. The hellorust package does this in the [`Makevars`](https://github.com/r-rust/hellorust/blob/master/src/Makevars) file.
