### PR TITLE
Ensure change `CARGO_HOME` to temp dir

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Description:
     Provides a function to convert 'PRQL' strings to 'SQL' strings.
     Combined with other R functions that take 'SQL' as an argument,
     'PRQL' can be used on R.
-Version: 0.0.4
+Version: 0.0.4.9000
 Authors@R:
     person("Tatsuya", "Shima", email = "ts1s1andn@gmail.com", role = c("aut", "cre"))
 URL: https://eitsupi.github.io/prqlr/, https://github.com/eitsupi/prqlr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,14 @@
 # prqlr (development version)
 
+- Changes to the installation process
+  - `CARGO_HOME` is now set to the temporary directory during installation
+    if the environment variable `NOT_CRAN` is not set to `true`
+    [to avoid writing in HOME](https://github.com/r-rust/faq). (#25, #27, #29)
+
 # prqlr 0.0.4
 
 - Changes to the installation process
   - Change Rust toolchain for Windows from GNU to MSVC. (#22)
-  - `CARGO_HOME` is now set to the temporary directory during installation
-    if the environment variable `NOT_CRAN` is not set to `true`
-    [to avoid writing in HOME](https://github.com/r-rust/faq). (#25, #27)
 
 # prqlr 0.0.3
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# prqlr (development version)
+
 # prqlr 0.0.4
 
 - Changes to the installation process

--- a/src/Makevars
+++ b/src/Makevars
@@ -14,7 +14,7 @@ $(STATLIB):
 	# to set it here to ensure cargo can be invoked. It is appended to PATH and
 	# therefore is only used if cargo is absent from the user's PATH.
 	if [ "$(NOT_CRAN)" != "true" ] && [ "$(NOT_CRAN)" != "TRUE" ]; then \
-		CARGO_HOME=$(CARGOTMP); \
+		export CARGO_HOME=$(CARGOTMP); \
 	fi && \
 	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -24,7 +24,7 @@ $(STATLIB):
 
 	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
 	if [ "$(NOT_CRAN)" != "true" ] && [ "$(NOT_CRAN)" != "TRUE" ]; then \
-		CARGO_HOME=$(CARGOTMP); \
+		export CARGO_HOME=$(CARGOTMP); \
 	fi && \
 	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \


### PR DESCRIPTION
Because `CARGO_HOME` was not exported, `prqlr` was writing `~/.cargo`.
After making this change I installed on a Docker container and verified that `~/.cargo` was not generated.