### PR TITLE
chore: Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,18 +4,16 @@
 	"features": {
 		"ghcr.io/devcontainers/features/rust:1": {
 			"version": "latest"
+		},
+		"ghcr.io/rocker-org/devcontainer-features/r-packages:1": {
+			"packages": "github::extendr/rextendr"
 		}
 	},
 	"customizations": {
 		"vscode": {
-			"settings": {
-				"terminal.integrated.defaultProfile.linux": "zsh"
-			},
 			"extensions": [
 				"EditorConfig.EditorConfig"
 			]
 		}
-	},
-	"remoteUser": "rstudio",
-	"postCreateCommand": "R -q -e 'remotes::install_github(\"extendr/rextendr\")'"
+	}
 }


### PR DESCRIPTION
- Use the new `ghcr.io/rocker-org/devcontainer-features/r-packages` Feature to install R packages.
- Remove `terminal.integrated.defaultProfile.linux` vscode setting in favor of users' choise.
- Remove useless `remoteUser` property.