### PR TITLE
Move the script for development to `dev` directory

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 ^vignettes/articles$
 ^cran-comments\.md$
 ^CRAN-SUBMISSION$
+^dev$

--- a/dev/generate-license-note.R
+++ b/dev/generate-license-note.R
@@ -1,7 +1,7 @@
 # A script to generate LICENSE.note
 # cargo-license <https://crates.io/crates/cargo-license> must be installed on the system to use this.
 #
-# Usage: Rscript tools/generate-license-note.R
+# Usage: Rscript dev/generate-license-note.R
 
 manifest_path <- file.path("src", "rust", "Cargo.toml")
 license_note_path <- file.path("LICENSE.note")


### PR DESCRIPTION
Scripts used only during development should not be included after the build.