### PR TITLE
Add setting for rust-analyzer in VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,12 @@
 		"vscode": {
 			"extensions": [
 				"EditorConfig.EditorConfig"
-			]
+			],
+			"settings": {
+				"rust-analyzer.linkedProjects": [
+					"${containerWorkspaceFolder}/src/rust/Cargo.toml"
+				]
+			}
 		}
 	}
 }


### PR DESCRIPTION
If `Cargo.toml` does not exist in the project root, rust-analyzer will not work properly without this setting.