### PR TITLE
Remove `rextendr` and `lintr` from Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,10 +12,8 @@ BugReports: https://github.com/eitsupi/prqlr/issues
 Depends:
     R (>= 4.2)
 Suggests:
-    rextendr,
     knitr,
     rmarkdown,
-    lintr,
     DBI,
     RSQLite,
     tidyquery,


### PR DESCRIPTION
Remove packages from Suggests that are not needed for package builds and tests.