### PR TITLE
Add Config/Needs/dev field and Config/Needs/website to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,3 +30,11 @@ SystemRequirements: Cargo (rustc package manager)
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 Config/rextendr/version: 0.2.0.9000
+Config/Needs/dev:
+    extendr/rextendr,
+    data.table,
+    dplyr,
+    lintr,
+    styler,
+    purrr,
+    RcppTOML

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,3 +38,6 @@ Config/Needs/dev:
     styler,
     purrr,
     RcppTOML
+Config/Needs/website:
+    pkgdown,
+    extendr/rextendr


### PR DESCRIPTION
We can install these packages via `remotes::install_deps(dependencies = "config/needs/dev")`.