### PR TITLE
Add PRQL engine for knitr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,7 @@ BugReports: https://github.com/eitsupi/prqlr/issues
 Depends:
     R (>= 4.2)
 Suggests:
+    utils,
     knitr,
     rmarkdown,
     DBI,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Description:
     Provides a function to convert 'PRQL' strings to 'SQL' strings.
     Combined with other R functions that take 'SQL' as an argument,
     'PRQL' can be used on R.
-Version: 0.1.0.9001
+Version: 0.1.0.9002
 Authors@R:
     person("Tatsuya", "Shima", email = "ts1s1andn@gmail.com", role = c("aut", "cre"))
 URL: https://eitsupi.github.io/prqlr/, https://github.com/eitsupi/prqlr

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -1,0 +1,17 @@
+#' @title PRQL knitr engine
+#' @noRd
+eng_prql <- function(options) {
+  prql_code <- options$code |>
+    paste0(collapse = "\n")
+  sql_code <- prql_code |>
+    prql_compile()
+
+  options$code <- sql_code
+
+  # elm coincidentally provides the best syntax highlight for prql.
+  options$engine <- "elm"
+
+  eng_sql <- utils::getFromNamespace("eng_sql", "knitr")
+  eng_sql(options) |>
+    sub(sql_code, prql_code, x = _, fixed = TRUE)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,5 @@
+.onLoad <- function(...) {
+  if (requireNamespace("knitr", quietly = TRUE)) {
+    knitr::knit_engines$set(prql = eng_prql)
+  }
+}

--- a/tests/testthat/_snaps/knitr-engine.md
+++ b/tests/testthat/_snaps/knitr-engine.md
@@ -1,0 +1,48 @@
+# Snapshot test of knitr-engine
+
+    Code
+      cat(paste0(readLines(output), collapse = "\n"))
+    Output
+      ---
+      output: github_document
+      ---
+      
+      
+      
+      
+      ```elm
+      from mtcars | filter cyl > 6 | select [mpg] | take 3
+      ```
+      
+      
+      
+      
+      Table: 3 records
+      
+      |  mpg|
+      |----:|
+      | 18.7|
+      | 14.3|
+      | 16.4|
+      
+      
+      ```elm
+      from mtcars
+      filter cyl > 6
+      select [cyl, mpg]
+      derive [mpg_int = round 0 mpg]
+      take 3
+      ```
+      
+      
+      
+      
+      Table: 3 records
+      
+      | cyl|  mpg| mpg_int|
+      |---:|----:|-------:|
+      |   8| 18.7|      19|
+      |   8| 14.3|      14|
+      |   8| 16.4|      16|
+      
+

--- a/tests/testthat/files/test-engine.Rmd
+++ b/tests/testthat/files/test-engine.Rmd
@@ -1,0 +1,25 @@
+---
+output: github_document
+---
+
+```{r, echo=FALSE}
+library(DBI)
+con <- dbConnect(RSQLite::SQLite(), ":memory:")
+dbWriteTable(con, "mtcars", mtcars)
+```
+
+```{prql, connection = "con"}
+from mtcars | filter cyl > 6 | select [mpg] | take 3
+```
+
+```{prql, connection = "con"}
+from mtcars
+filter cyl > 6
+select [cyl, mpg]
+derive [mpg_int = round 0 mpg]
+take 3
+```
+
+```{r, echo=FALSE}
+dbDisconnect(con)
+```

--- a/tests/testthat/test-knitr-engine.R
+++ b/tests/testthat/test-knitr-engine.R
@@ -1,8 +1,12 @@
+test_that("Set prql knitr engine", {
+  expect_true("prql" %in% names(knitr::knit_engines$get()))
+})
+
 test_that("Snapshot test of knitr-engine", {
   input <- file.path("files", "test-engine.Rmd")
   output <- tempfile(fileext = "md")
 
-  knitr::knit(input, output)
+  knitr::knit(input, output, quiet = TRUE)
 
   expect_snapshot(
     readLines(output) |>

--- a/tests/testthat/test-knitr-engine.R
+++ b/tests/testthat/test-knitr-engine.R
@@ -1,0 +1,12 @@
+test_that("Snapshot test of knitr-engine", {
+  input <- file.path("files", "test-engine.Rmd")
+  output <- tempfile(fileext = "md")
+
+  knitr::knit(input, output)
+
+  expect_snapshot(
+    readLines(output) |>
+      paste0(collapse = "\n") |>
+      cat()
+  )
+})

--- a/vignettes/in_rmarkdown.Rmd
+++ b/vignettes/in_rmarkdown.Rmd
@@ -1,0 +1,60 @@
+---
+title: Use PRQL in R Markdown
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Use PRQL in R Markdown}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+Loading `{prqlr}` makes the `prql` code chunks executable on R Markdown files.
+
+```{r}
+library(prqlr)
+"prql" %in% names(knitr::knit_engines$get())
+```
+
+Usage is the same as for [SQL code chunks](https://bookdown.org/yihui/rmarkdown/language-engines.html#sql).
+
+For example, let's render an R Markdown file named `test.Rmd` with the following contents
+with the `knitr::knit()` function.
+
+````markdown
+```{r, echo=FALSE}`r ''`
+library(DBI)
+library(prqlr)
+con <- dbConnect(RSQLite::SQLite(), ":memory:")
+dbWriteTable(con, "mtcars", mtcars)
+```
+
+```{prql, connection = "con"}`r ''`
+from mtcars
+filter cyl > 6
+select [cyl, mpg]
+derive [mpg_int = round 0 mpg]
+take 3
+```
+````
+
+After rendering, a Markdown file named `test.md` is generated with the following contents.
+
+````markdown
+```elm
+from mtcars
+filter cyl > 6
+select [cyl, mpg]
+derive [mpg_int = round 0 mpg]
+take 3
+```
+
+Table: 3 records
+
+| cyl|  mpg| mpg_int|
+|---:|----:|-------:|
+|   8| 18.7|      19|
+|   8| 14.3|      14|
+|   8| 16.4|      16|
+````
+
+Note that the syntax highlighting of Elm is the best for PRQL,
+so the output code blocks are marked as `elm`.


### PR DESCRIPTION
Enables PRQL engine for knitr that wraps knitr's SQL engine.