### PR TITLE
ci: set workflow for check 'Minimum Supported Rust Version'

### DIFF
--- a/.github/workflows/check-rust.yml
+++ b/.github/workflows/check-rust.yml
@@ -1,0 +1,28 @@
+name: Check Rust code
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - src/rust/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - src/rust/**
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-min-rust-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-msrv
+      - name: Verify minimum rust version
+        run: cargo-msrv --path src/rust/ verify

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -2,6 +2,7 @@
 name = "prqlr"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.63"
 
 [lib]
 crate-type = ['staticlib']


### PR DESCRIPTION
Close #50

Also set the `package.rust-version` field to Cargo.toml.