### PR TITLE
fix: ensure `format=TURE` in knitr engine

### DIFF
--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -12,7 +12,7 @@ eng_prql <- function(options) {
   signature_comment <- .get_engine_opt(options, "signature_comment", getOption("prqlr.signature_comment", TRUE))
 
   sql_code <- prql_code |>
-    prql_compile(target = target, signature_comment = signature_comment)
+    prql_compile(target = target, format = TRUE, signature_comment = signature_comment)
 
   # elm coincidentally provides the best syntax highlight for prql.
   options$lang <- options$lang %||% "elm"

--- a/tests/testthat/_snaps/knitr-engine.md
+++ b/tests/testthat/_snaps/knitr-engine.md
@@ -94,3 +94,29 @@
       |   8| 16.4|      16|
       
 
+---
+
+    Code
+      withr::with_options(list(prqlr.target = "sql.mssql", prqlr.format = FALSE,
+        prqlr.signature_comment = FALSE), .knit_file("minimal.Rmd"))
+    Output
+      
+      ```elm
+      from mtcars
+      filter cyl > 6
+      select [cyl, mpg]
+      derive [mpg_int = round 0 mpg]
+      take 3
+      ```
+      
+      ```sql
+      SELECT
+        TOP (3) cyl,
+        mpg,
+        ROUND(mpg, 0) AS mpg_int
+      FROM
+        mtcars
+      WHERE
+        cyl > 6
+      ```
+

--- a/tests/testthat/files/minimal.Rmd
+++ b/tests/testthat/files/minimal.Rmd
@@ -1,0 +1,2 @@
+```{prql, file="simple.prql"}
+```

--- a/tests/testthat/test-knitr-engine.R
+++ b/tests/testthat/test-knitr-engine.R
@@ -17,4 +17,11 @@ test_that("Set prql knitr engine", {
 test_that("Snapshot test of knitr-engine", {
   expect_snapshot(.knit_file("r-style-opts.Rmd"), cran = TRUE)
   expect_snapshot(.knit_file("yaml-style-opts.Rmd"), cran = TRUE)
+  expect_snapshot(
+    withr::with_options(
+      list(prqlr.target = "sql.mssql", prqlr.format = FALSE, prqlr.signature_comment = FALSE),
+      .knit_file("minimal.Rmd")
+    ),
+    cran = TRUE
+  )
 })


### PR DESCRIPTION
If this change is not made, the display will be broken when `prqlr.format=FALSE` is set in the options.