### PR TITLE
refactor: get available target names automatically from upstream

### DIFF
--- a/R/extendr-wrappers.R
+++ b/R/extendr-wrappers.R
@@ -34,5 +34,8 @@ rq_to_sql <- function(rq_json) .Call(wrap__rq_to_sql, rq_json)
 #' @noRd
 compiler_version <- function() .Call(wrap__compiler_version)
 
+#' @noRd
+dialects <- function() .Call(wrap__dialects)
+
 
 # nolint end

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -435,7 +435,7 @@ dependencies = [
 [[package]]
 name = "prql-compiler"
 version = "0.4.2"
-source = "git+https://github.com/PRQL/prql?rev=58d4bccda5dd35c7579dd33ffef546d863b85c65#58d4bccda5dd35c7579dd33ffef546d863b85c65"
+source = "git+https://github.com/eitsupi/prql?rev=b8ccf3e51337e70c86b9c960eeb277c1a6e5bb8c#b8ccf3e51337e70c86b9c960eeb277c1a6e5bb8c"
 dependencies = [
  "anyhow",
  "ariadne",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -12,5 +12,5 @@ name = "prqlr"
 # extendr-api = "0.3.1"
 extendr-api = { git = "https://github.com/extendr/extendr", rev = "974cddc4ee5a4c3ab10e8bf85772b74c0a182f32" }
 # prql-compiler = { version = "0.4.2", default-features = false }
-prql-compiler = { git = "https://github.com/PRQL/prql", rev = "58d4bccda5dd35c7579dd33ffef546d863b85c65", default-features = false }
+prql-compiler = { git = "https://github.com/eitsupi/prql", rev = "b8ccf3e51337e70c86b9c960eeb277c1a6e5bb8c", default-features = false }
 anyhow = "1.0.68"

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -81,6 +81,12 @@ pub fn compiler_version() -> String {
     prql_compiler::PRQL_VERSION.to_string()
 }
 
+/// @noRd
+#[extendr]
+pub fn dialects() -> Vec<&'static str> {
+    prql_compiler::sql::DIALECT_NAMES.to_vec()
+}
+
 extendr_module! {
     mod prqlr;
     fn compile;
@@ -88,4 +94,5 @@ extendr_module! {
     fn pl_to_rq;
     fn rq_to_sql;
     fn compiler_version;
+    fn dialects;
 }


### PR DESCRIPTION
The currently available target names are read from the prql-compiler source code and copied manually to the following lines.

https://github.com/eitsupi/prqlr/blob/380b092c100cdf6a9590aceadd388d677cd62502/R/compile.R#L48-L60

Update to automatically retrieve available SQL dialect names from prql-compiler.