### PR TITLE
chore: not to remove `src/rust/target/release/build` during development

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -16,10 +16,12 @@ $(STATLIB):
 	if [ "$(NOT_CRAN)" != "true" ] && [ "$(NOT_CRAN)" != "TRUE" ]; then \
 		export CARGO_HOME=$(CARGOTMP); \
 	fi && \
-	export PATH="$(PATH):$(HOME)/.cargo/bin" && \
+		export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
-	rm -Rf $(CARGOTMP)
-	rm -Rf $(LIBDIR)/build
+	if [ "$(NOT_CRAN)" != "true" ] && [ "$(NOT_CRAN)" != "TRUE" ]; then \
+		rm -Rf $(CARGOTMP) && \
+		rm -Rf $(LIBDIR)/build; \
+	fi
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -25,11 +25,13 @@ $(STATLIB):
 	if [ "$(NOT_CRAN)" != "true" ] && [ "$(NOT_CRAN)" != "TRUE" ]; then \
 		export CARGO_HOME=$(CARGOTMP); \
 	fi && \
-	export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
+		export CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER="$(CARGO_LINKER)" && \
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
 		cargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
-	rm -Rf $(CARGOTMP)
-	rm -Rf $(LIBDIR)/build
+	if [ "$(NOT_CRAN)" != "true" ] && [ "$(NOT_CRAN)" != "TRUE" ]; then \
+		rm -Rf $(CARGOTMP) && \
+		rm -Rf $(LIBDIR)/build; \
+	fi
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)


### PR DESCRIPTION
This change reduces build time during development.