### PR TITLE
refactor: use snake_case for class names in R

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -17,7 +17,7 @@
 #' @noRd
 unwrap <- function(result, call = sys.call(1L)) {
   # if not result
-  if (!inherits(result, "Result") && (!is.list(result) || !all(names(result) %in% c("ok", "err")))) {
+  if (!inherits(result, "rust_result") && (!is.list(result) || !all(names(result) %in% c("ok", "err")))) {
     stop("Internal error: cannot unwrap non result")
   }
 

--- a/src/rust/src/utils.rs
+++ b/src/rust/src/utils.rs
@@ -10,8 +10,8 @@ where
         Ok(x) => list!(ok = x.into_robj(), err = extendr_api::NULL),
         Err(x) => list!(ok = extendr_api::NULL, err = x.to_string()),
     }
-    .set_class(&["Result"])
-    .unwrap()
+    .set_class(&["rust_result"])
+    .unwrap_or_default()
     .as_list()
-    .unwrap()
+    .unwrap_or_default()
 }


### PR DESCRIPTION
Rename `Result` to `rust_result`.

It also includes minor changes replacing `unwrap` to `unwrap_or_default`.