### PR TITLE
refactor: remove unused dependencies

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -443,7 +443,6 @@ dependencies = [
 name = "prqlr"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "extendr-api",
  "prql-compiler",
 ]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -14,4 +14,3 @@ extendr-api = { git = "https://github.com/extendr/extendr", rev = "974cddc4ee5a4
 # prql-compiler = { version = "0.5.1", default-features = false }
 # prql-compiler 0.5.1 is not compatible with Rust 1.64, so a slightly modified version is installed from the fork. https://github.com/PRQL/prql/pull/1561
 prql-compiler = { git = "https://github.com/eitsupi/prql", rev = "c9a123336417629ffda8b435a11110bf1180d42d", default-features = false }
-anyhow = "1.0.68"


### PR DESCRIPTION
`anyhow` is no longer imported in prqlr.