### PR TITLE
fix: bump extendr-api and libR-sys to 0.4.0 for supporting arm64 Linux

### DIFF
--- a/LICENSE.note
+++ b/LICENSE.note
@@ -117,7 +117,7 @@ License:     Apache-2.0 OR MIT
 
 Name:        extendr-api
 Repository:  https://github.com/extendr/extendr
-Authors:     andy-thomason, Thomas Down, Mossa Merhi Reimert, Claus O. Wilke, Hiroaki Yutani, Ilia A. Kosenkov
+Authors:     andy-thomason, Thomas Down, Mossa Merhi Reimert, Claus O. Wilke, Hiroaki Yutani, Ilia A. Kosenkov, Michael Milton
 License:     MIT
 
 -------------------------------------------------------------
@@ -179,8 +179,8 @@ License:     Apache-2.0 OR MIT
 -------------------------------------------------------------
 
 Name:        libR-sys
-Repository:  
-Authors:     andy-thomason, Thomas Down, Mossa Merhi Reimert, Claus O. Wilke, Ilia Kosenkov, Hiroaki Yutani
+Repository:  https://github.com/extendr/libR-sys
+Authors:     andy-thomason, Thomas Down, Mossa Merhi Reimert, Claus O. Wilke, Ilia A. Kosenkov, Hiroaki Yutani
 License:     MIT
 
 -------------------------------------------------------------

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # prqlr (development version)
 
+## Bug fixes
+
+- Thanks to new version of `extendr` and `libR-sys`, it can now be installed on arm64 Linux. (#90)
+
 # prqlr 0.2.0
 
 ## Breaking changes

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -197,7 +197,8 @@ dependencies = [
 [[package]]
 name = "extendr-api"
 version = "0.4.0"
-source = "git+https://github.com/extendr/extendr?rev=e0326174278ece5d28690a16234eea25b1ccf884#e0326174278ece5d28690a16234eea25b1ccf884"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e36d66fa307948c291a6fc5b09d8295dd58e88ab5e8d782d30e23670113e9ab"
 dependencies = [
  "extendr-engine",
  "extendr-macros",
@@ -209,7 +210,8 @@ dependencies = [
 [[package]]
 name = "extendr-engine"
 version = "0.4.0"
-source = "git+https://github.com/extendr/extendr?rev=e0326174278ece5d28690a16234eea25b1ccf884#e0326174278ece5d28690a16234eea25b1ccf884"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8298d5a2e38bb91820b92bbd7e5aaf1d3b95ed9f096fc66393c50af38ff8155d"
 dependencies = [
  "libR-sys",
 ]
@@ -217,7 +219,8 @@ dependencies = [
 [[package]]
 name = "extendr-macros"
 version = "0.4.0"
-source = "git+https://github.com/extendr/extendr?rev=e0326174278ece5d28690a16234eea25b1ccf884#e0326174278ece5d28690a16234eea25b1ccf884"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09bf0849f0d48209be8163378248137fed5ccb5f464d171cf93a19f31a9e6c67"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -196,8 +196,8 @@ dependencies = [
 
 [[package]]
 name = "extendr-api"
-version = "0.3.1"
-source = "git+https://github.com/extendr/extendr?rev=974cddc4ee5a4c3ab10e8bf85772b74c0a182f32#974cddc4ee5a4c3ab10e8bf85772b74c0a182f32"
+version = "0.4.0"
+source = "git+https://github.com/extendr/extendr?rev=e0326174278ece5d28690a16234eea25b1ccf884#e0326174278ece5d28690a16234eea25b1ccf884"
 dependencies = [
  "extendr-engine",
  "extendr-macros",
@@ -208,16 +208,16 @@ dependencies = [
 
 [[package]]
 name = "extendr-engine"
-version = "0.3.1"
-source = "git+https://github.com/extendr/extendr?rev=974cddc4ee5a4c3ab10e8bf85772b74c0a182f32#974cddc4ee5a4c3ab10e8bf85772b74c0a182f32"
+version = "0.4.0"
+source = "git+https://github.com/extendr/extendr?rev=e0326174278ece5d28690a16234eea25b1ccf884#e0326174278ece5d28690a16234eea25b1ccf884"
 dependencies = [
  "libR-sys",
 ]
 
 [[package]]
 name = "extendr-macros"
-version = "0.3.1"
-source = "git+https://github.com/extendr/extendr?rev=974cddc4ee5a4c3ab10e8bf85772b74c0a182f32#974cddc4ee5a4c3ab10e8bf85772b74c0a182f32"
+version = "0.4.0"
+source = "git+https://github.com/extendr/extendr?rev=e0326174278ece5d28690a16234eea25b1ccf884#e0326174278ece5d28690a16234eea25b1ccf884"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -280,12 +280,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libR-sys"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a97fd689379c62156b5c9b7b368d118ef660ad8c220a2f3e4c655529ad52384"
-dependencies = [
- "winapi",
-]
+checksum = "cd728a97b9b0975f546bc865a7413e0ce6f98a8f6cea52e77dc5ee0bcea00adf"
 
 [[package]]
 name = "libc"
@@ -660,28 +657,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "yansi"

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -9,8 +9,8 @@ crate-type = ['staticlib']
 name = "prqlr"
 
 [dependencies]
-# extendr-api = "0.3.1"
-extendr-api = { git = "https://github.com/extendr/extendr", rev = "974cddc4ee5a4c3ab10e8bf85772b74c0a182f32" }
+# extendr-api = "0.4.0"
+extendr-api = { git = "https://github.com/extendr/extendr", rev = "e0326174278ece5d28690a16234eea25b1ccf884" }
 # prql-compiler = { version = "0.5.1", default-features = false }
 # prql-compiler 0.5.1 is not compatible with Rust 1.64, so a slightly modified version is installed from the fork. https://github.com/PRQL/prql/pull/1561
 prql-compiler = { git = "https://github.com/eitsupi/prql", rev = "c9a123336417629ffda8b435a11110bf1180d42d", default-features = false }

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -9,8 +9,8 @@ crate-type = ['staticlib']
 name = "prqlr"
 
 [dependencies]
-# extendr-api = "0.4.0"
-extendr-api = { git = "https://github.com/extendr/extendr", rev = "e0326174278ece5d28690a16234eea25b1ccf884" }
+extendr-api = "0.4.0"
+# extendr-api = { git = "https://github.com/extendr/extendr", rev = "e0326174278ece5d28690a16234eea25b1ccf884" }
 # prql-compiler = { version = "0.5.1", default-features = false }
 # prql-compiler 0.5.1 is not compatible with Rust 1.64, so a slightly modified version is installed from the fork. https://github.com/PRQL/prql/pull/1561
 prql-compiler = { git = "https://github.com/eitsupi/prql", rev = "c9a123336417629ffda8b435a11110bf1180d42d", default-features = false }


### PR DESCRIPTION
This version of extendr-api contains arm64 Linux support.

Fix #88