### PR TITLE
fix: update `package.rust_version` to 1.60 (MSRV from csv v1.2.0)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Bug fixes
 
 - Thanks to new version of `extendr` and `libR-sys`, it can now be installed on arm64 Linux. (#90)
+- Now buildable with Rust version 1.60 (#94)
 
 # prqlr 0.2.0
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prqlr"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.60"
 
 [lib]
 crate-type = ['staticlib']


### PR DESCRIPTION
Fix #91

It will be able to build with CRAN's arm64 mac builder (Rust 1.62 now) and Posit Package Manager's Ubuntu builder (Rust 1.61 now).