### PR TITLE
chore: install prql-compiler from the latest commit

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 [[package]]
 name = "prql-compiler"
 version = "0.6.0"
-source = "git+https://github.com/PRQL/prql?rev=57f43709cd9a4840cb24031048c7348e1524dbbe#57f43709cd9a4840cb24031048c7348e1524dbbe"
+source = "git+https://github.com/PRQL/prql?rev=329d2431a795cdd65240ee97bbcec96f3b3ac839#329d2431a795cdd65240ee97bbcec96f3b3ac839"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -437,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f064eb7b163863163c29801910f763c6bfb563b8a8ca4c54193da4c1eea57547"
+checksum = "0366f270dbabb5cc2e4c88427dc4c08bba144f81e32fbd459a013f26a4d16aa0"
 dependencies = [
  "log",
  "serde",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -12,4 +12,4 @@ name = "prqlr"
 extendr-api = "0.4.0"
 # extendr-api = { git = "https://github.com/extendr/extendr", rev = "e0326174278ece5d28690a16234eea25b1ccf884" }
 # prql-compiler = { version = "0.6.0", default-features = false }
-prql-compiler = { git = "https://github.com/PRQL/prql", rev = "57f43709cd9a4840cb24031048c7348e1524dbbe", default-features = false }
+prql-compiler = { git = "https://github.com/PRQL/prql", rev = "329d2431a795cdd65240ee97bbcec96f3b3ac839", default-features = false }


### PR DESCRIPTION
The prql-compiler download fails in the test on macOS in #103, probably because I specified a commit on a PR from a fork in #101.
This PR switches to installation from the main branch, which should solve the problem in #103.