### PR TITLE
chore: support Rust 1.60

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Breaking changes
 
-- Based on [`prql-compiler`](https://github.com/prql/prql) 0.6.1  (#97, #99, #101, #106)
+- Based on [`prql-compiler`](https://github.com/prql/prql) 0.6.1  (#97, #99, #101, #106, #113)
 - The `prql_to_sql()` function (deprecated in favor of `prql_compile()` from `prqlr` 0.1.0) is removed. (#105)
 
 ## New features

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ install.packages("prqlr")
 install.packages("prqlr", repos = "https://eitsupi.r-universe.dev")
 ```
 
-For source installation, the Rust toolchain (Rust 1.65 or later) must be
+For source installation, the Rust toolchain (Rust 1.60 or later) must be
 configured. Please check the <https://github.com/r-rust/hellorust>
 repository for about Rust code in R packages.
 

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -302,8 +302,7 @@ dependencies = [
 [[package]]
 name = "prql-compiler"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5098924ebff82cd2847af36083411397190e69eb93dd97b6b2ea01716505cd"
+source = "git+https://github.com/eitsupi/prql?rev=cf4603d78bc471862379a8681ea6ade6accf45c6#cf4603d78bc471862379a8681ea6ade6accf45c6"
 dependencies = [
  "anyhow",
  "ariadne",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prqlr"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.60"
 
 [lib]
 crate-type = ['staticlib']
@@ -11,5 +11,6 @@ name = "prqlr"
 [dependencies]
 extendr-api = "0.4.0"
 # extendr-api = { git = "https://github.com/extendr/extendr", rev = "e0326174278ece5d28690a16234eea25b1ccf884" }
-prql-compiler = { version = "0.6.1", default-features = false }
-# prql-compiler = { git = "https://github.com/PRQL/prql", rev = "329d2431a795cdd65240ee97bbcec96f3b3ac839", default-features = false }
+# prql-compiler = { version = "0.6.1", default-features = false }
+# prql-compiler 0.6.1 is not compatible with Rust 1.64, so a slightly modified version is installed from the fork. https://github.com/PRQL/prql/pull/1561
+prql-compiler = { git = "https://github.com/eitsupi/prql", rev = "cf4603d78bc471862379a8681ea6ade6accf45c6", default-features = false }


### PR DESCRIPTION
Debian is still on Rust 1.63, so will switch to installing `prql-compiler` from the fork in order to pass the CRAN check.