### PR TITLE
build: refactor the generate-license-note script

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,10 +35,9 @@ Config/rextendr/version: 0.2.0.9000
 Config/Needs/dev:
     devtools,
     rextendr,
-    data.table,
-    dplyr,
     lintr,
     styler,
+    jsonlite,
     purrr,
     RcppTOML
 Config/Needs/website:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,6 +37,7 @@ Config/Needs/dev:
     rextendr,
     lintr,
     styler,
+    processx,
     jsonlite,
     purrr,
     RcppTOML

--- a/dev/generate-license-note.R
+++ b/dev/generate-license-note.R
@@ -28,8 +28,8 @@ list_license <- processx::run(
 )$stdout |>
   jsonlite::parse_json()
 
-.prep_authors <- function(authors, name) {
-  ifelse(!is.null(authors), authors, paste0(name, " authors")) |>
+.prep_authors <- function(authors, package) {
+  ifelse(!is.null(authors), authors, paste0(package, " authors")) |>
     gsub(r"(\ <.+?>)", "", x = _) |>
     gsub(r"(\|)", ", ", x = _)
 }

--- a/dev/generate-license-note.R
+++ b/dev/generate-license-note.R
@@ -15,31 +15,35 @@ note_header <- paste0(
 
 package_name <- RcppTOML::parseTOML(manifest_path)$package$name
 
-df_license <- processx::run(
+list_license <- processx::run(
   "cargo",
-  c("license", "--authors", "--tsv", "--avoid-build-deps", "--manifest-path", manifest_path)
-)$stdout |>
-  data.table::fread() |>
-  dplyr::select(name, repository, authors, license) |>
-  dplyr::filter(name != package_name) |>
-  dplyr::mutate(
-    authors = dplyr::case_when(
-      authors == "" ~ paste0(name, " authors"),
-      TRUE ~ authors
-    ) |>
-      stringr::str_remove_all(r"(\ <.+?>)") |>
-      stringr::str_replace_all(r"(\|)", ", ")
+  c(
+    "license",
+    "--authors",
+    "--json",
+    "--avoid-build-deps",
+    "--avoid-dev-deps",
+    "--manifest-path", manifest_path
   )
+)$stdout |>
+  jsonlite::parse_json()
 
-license_note <- df_license |>
-  purrr::pmap_chr(
-    \(name, repository, authors, license) {
+.prep_authors <- function(authors, name) {
+  ifelse(!is.null(authors), authors, paste0(name, " authors")) |>
+    gsub(r"(\ <.+?>)", "", x = _) |>
+    gsub(r"(\|)", ", ", x = _)
+}
+
+license_note <- list_license |>
+  purrr::keep(\(x) x$name != package_name) |>
+  purrr::map_chr(
+    \(x) {
       paste0(
         "\n",
-        "Name:        ", name, "\n",
-        "Repository:  ", repository, "\n",
-        "Authors:     ", authors, "\n",
-        "License:     ", license, "\n",
+        "Name:        ", x$name, "\n",
+        "Repository:  ", x$repository, "\n",
+        "Authors:     ", .prep_authors(x$authors, x$name), "\n",
+        "License:     ", x$license, "\n",
         "\n",
         "-------------------------------------------------------------"
       )


### PR DESCRIPTION
Remove `dplyr` and `data.table` from the dev dependencies.