### PR TITLE
test(knitr): Set options(knitr.sql.html_div = FALSE) for tests

### DIFF
--- a/tests/testthat/test-knitr-engine.R
+++ b/tests/testthat/test-knitr-engine.R
@@ -5,7 +5,11 @@ test_that("Set prql knitr engine", {
 .knit_file <- function(file_name) {
   file <- file.path("files", file_name)
   output <- tempfile(fileext = "md")
-  on.exit(unlink(output))
+  opts <- options(knitr.sql.html_div = FALSE)
+  on.exit({
+    unlink(output)
+    options(opts)
+  })
 
   suppressWarnings(knitr::knit(file, output, quiet = TRUE, envir = new.env()))
 


### PR DESCRIPTION
This is to disable `<div class="knitsql-table"></div>` in the output. Otherwise the change https://github.com/yihui/knitr/commit/10dd4c3d7f7f861175cf250f4f187505bf1039b0 will introduce the `<div>` (e.g., https://github.com/yihui/knitr-examples/commit/cd01db7a65413dfdde7cb2d89fa68faccafd20e0) due to https://github.com/yihui/knitr/blob/5ce55318ccb0e4b8dd15fba954e4503b7cb31a0f/R/engine.R#L669.

I'm not sure if you have plans for a new CRAN release in the near future. If you don't, I'll think about a workaround in **knitr** to avoid breaking your tests on CRAN. Thanks!