### PR TITLE
chore: use rextendr 0.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ RoxygenNote: 7.2.3
 SystemRequirements: Cargo (rustc package manager)
 VignetteBuilder: knitr
 Config/testthat/edition: 3
-Config/rextendr/version: 0.2.0.9000
+Config/rextendr/version: 0.3.0
 Config/Needs/dev:
     devtools,
     rextendr,

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,8 +22,7 @@ tasks:
     desc: Install R packages for development.
     cmds:
       - Rscript -e
-        'pak::repo_add(extendr = "https://extendr.r-universe.dev");
-        pak::local_install_deps(dependencies = c("all", "Config/Needs/dev", "Config/Needs/website"))'
+        'pak::local_install_deps(dependencies = c("all", "Config/Needs/dev", "Config/Needs/website"))'
 
   install-rust-tools:
     internal: true


### PR DESCRIPTION
The new version of rextendr is now on CRAN.