### PR TITLE
chore: should not install cargo and rustc via apt in devcontainer

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -19,6 +19,8 @@ tasks:
 
   install-r-tools:
     internal: true
+    env:
+      PKG_SYSREQS: FALSE
     desc: Install R packages for development.
     cmds:
       - Rscript -e


### PR DESCRIPTION
I noticed that when `postCreateCommand` is executed, pak misses `cargo` and `rustc` (rextendr's system requirements) and try to install them via apt.
Off course they are already installed and should not install them via apt.