### PR TITLE
chore: should remove the vendor dir on CRAN

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@
   - Set `SystemRequirements: Cargo (Rust's package manager), rustc` in the DESCRIPTION file. (#153)
   - This package now includes the `configure` and `configure.win` scripts to check the cargo command. (#149)
   - Set `CARGO_BUILD_JOBS=2` if not `NOT_CRAN=true` during installation. (#151)
-  - Supports dependent Rust crates vendoring. (#152)
+  - Supports dependent Rust crates vendoring. (#152, #159)
   - Update the `LICENSE.note` file for Rust crates vendoring. (#156)
 
 # prqlr 0.4.0

--- a/src/Makevars
+++ b/src/Makevars
@@ -28,12 +28,11 @@ $(STATLIB):
 		export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 		cargo build --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 	if [ "$(NOT_CRAN)" != "true" ]; then \
-		rm -Rf $(CARGOTMP) && \
-		rm -Rf $(LIBDIR)/build; \
+		rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(LIBDIR)/build; \
 	fi
 
 C_clean:
 	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS)
 
 clean:
-	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) $(VENDOR_DIR) ./rust/target
+	rm -Rf $(SHLIB) $(STATLIB) $(OBJECTS) ./rust/target

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -38,8 +38,7 @@ $(STATLIB):
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(CURDIR)/$(TARGET_DIR)/libgcc_mock" && \
 		cargo build --target=$(TARGET) --lib --release --manifest-path=./rust/Cargo.toml --target-dir $(TARGET_DIR)
 	if [ "$(NOT_CRAN)" != "true" ]; then \
-		rm -Rf $(CARGOTMP) && \
-		rm -Rf $(LIBDIR)/build; \
+		rm -Rf $(CARGOTMP) $(VENDOR_DIR) $(LIBDIR)/build; \
 	fi
 
 C_clean:


### PR DESCRIPTION
Part of #148

This is needed to avoid source code checking like:

```
* checking line endings in C/C++/Fortran sources/headers ... NOTE
Found the following sources/headers with CR or CRLF line endings:
  src/rust/vendor/stacker/src/arch/windows.c
Some Unix compilers require LF line endings.
```