### PR TITLE
docs: update AUTHORS format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description:
 Version: 0.5.1.9000
 Authors@R:
     c(person("Tatsuya", "Shima", email = "ts1s1andn@gmail.com", role = c("aut", "cre")),
-      person(given = "The authors of the dependency Rust crates", role = c("aut"),
+      person("Authors of the dependency Rust crates", role = "aut",
              comment = "see inst/AUTHORS file for details"))
 URL: https://eitsupi.github.io/prqlr/, https://github.com/eitsupi/prqlr
 BugReports: https://github.com/eitsupi/prqlr/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Miscellaneous
 
-- Update the `inst/AUTHORS` file's format. (#169)
+- Update the `Authors` field of the DESCRIPTION file and the `inst/AUTHORS` file's format. (#169)
 
 # prqlr 0.5.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # prqlr (development version)
 
+## Miscellaneous
+
+- Update the `inst/AUTHORS` file's format. (#169)
+
 # prqlr 0.5.1
 
 - Based on [`prql-compiler`](https://github.com/prql/prql) 0.9.4 (#164)

--- a/dev/generate-authors.R
+++ b/dev/generate-authors.R
@@ -30,16 +30,14 @@ write_authors <- function(path = ".", quiet = FALSE, force = TRUE) {
     stringi::stri_replace_all_regex(authors, r"(\|)", ", ")
   }
 
-  authors_header <- "The authors of the dependency Rust crates:"
+  authors_header <- "Authors of dependent Rust crates:"
 
   authors_body <- list_authors |>
     purrr::discard(function(x) x$name %in% package_names || is.null(x$authors)) |>
     purrr::map_chr(
       function(x) {
         paste0(
-          "\n",
-          x$name, " (version ", x$version, "):\n",
-          "  ", .prep_authors(x$authors)
+          "  - ", x$name, " (version ", x$version, "): ", .prep_authors(x$authors)
         )
       }
     )

--- a/dev/generate-authors.R
+++ b/dev/generate-authors.R
@@ -26,22 +26,20 @@ write_authors <- function(path = ".", quiet = FALSE, force = TRUE) {
     purrr::pluck("packages") |>
     purrr::map_chr("name")
 
-  .prep_authors <- function(authors, package) {
-    ifelse(!is.null(authors), authors, paste0(package, " authors")) |>
-      stringi::stri_replace_all_regex(r"(\ <.+?>)", "") |>
-      stringi::stri_replace_all_regex(r"(\|)", ", ")
+  .prep_authors <- function(authors) {
+    stringi::stri_replace_all_regex(authors, r"(\|)", ", ")
   }
 
   authors_header <- "The authors of the dependency Rust crates:"
 
   authors_body <- list_authors |>
-    purrr::discard(function(x) x$name %in% package_names) |>
+    purrr::discard(function(x) x$name %in% package_names || is.null(x$authors)) |>
     purrr::map_chr(
       function(x) {
         paste0(
           "\n",
           x$name, " (version ", x$version, "):\n",
-          "  ", .prep_authors(x$authors, x$name)
+          "  ", .prep_authors(x$authors)
         )
       }
     )

--- a/inst/AUTHORS
+++ b/inst/AUTHORS
@@ -1,37 +1,19 @@
 The authors of the dependency Rust crates:
 
-addr2line (version 0.21.0):
-  addr2line authors
-
 adler (version 1.0.2):
-  Jonas Schievink
+  Jonas Schievink <jonasschievink@gmail.com>
 
 ahash (version 0.7.6):
-  Tom Kaitchuck
+  Tom Kaitchuck <Tom.Kaitchuck@gmail.com>
 
 aho-corasick (version 1.0.5):
-  Andrew Gallant
-
-anstream (version 0.3.2):
-  anstream authors
-
-anstyle (version 1.0.2):
-  anstyle authors
-
-anstyle-parse (version 0.2.1):
-  anstyle-parse authors
-
-anstyle-query (version 1.0.0):
-  anstyle-query authors
-
-anstyle-wincon (version 1.0.2):
-  anstyle-wincon authors
+  Andrew Gallant <jamslam@gmail.com>
 
 anyhow (version 1.0.75):
-  David Tolnay
+  David Tolnay <dtolnay@gmail.com>
 
 ariadne (version 0.3.0):
-  Joshua Barretto
+  Joshua Barretto <joshua.s.barretto@gmail.com>
 
 backtrace (version 0.3.69):
   The Rust Project Developers
@@ -40,61 +22,55 @@ bitflags (version 2.4.0):
   The Rust Project Developers
 
 cc (version 1.0.83):
-  Alex Crichton
+  Alex Crichton <alex@alexcrichton.com>
 
 cfg-if (version 1.0.0):
-  Alex Crichton
+  Alex Crichton <alex@alexcrichton.com>
 
 chumsky (version 0.9.2):
-  Joshua Barretto
-
-colorchoice (version 1.0.0):
-  colorchoice authors
+  Joshua Barretto <joshua.s.barretto@gmail.com>
 
 csv (version 1.2.2):
-  Andrew Gallant
+  Andrew Gallant <jamslam@gmail.com>
 
 csv-core (version 0.1.10):
-  Andrew Gallant
+  Andrew Gallant <jamslam@gmail.com>
 
 either (version 1.9.0):
   bluss
 
 enum-as-inner (version 0.6.0):
-  Benjamin Fry
+  Benjamin Fry <benjaminfry@me.com>
 
 errno (version 0.3.3):
-  Chris Wong
+  Chris Wong <lambda.fairy@gmail.com>
 
 errno-dragonfly (version 0.1.2):
-  Michael Neumann
+  Michael Neumann <mneumann@ntecs.de>
 
 extendr-api (version 0.4.0):
-  andy-thomason, Thomas Down, Mossa Merhi Reimert, Claus O. Wilke, Hiroaki Yutani, Ilia A. Kosenkov, Michael Milton
+  andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Hiroaki Yutani, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>, Michael Milton <michael.r.milton@gmail.com>
 
 extendr-engine (version 0.4.0):
-  andy-thomason, Thomas Down, Mossa Merhi Reimert, Claus O. Wilke, Hiroaki Yutani, Ilia A. Kosenkov
+  andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Hiroaki Yutani, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>
 
 extendr-macros (version 0.4.0):
-  andy-thomason, Thomas Down, Mossa Merhi Reimert, Claus O. Wilke, Hiroaki Yutani, Ilia A. Kosenkov
+  andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Hiroaki Yutani, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>
 
 getrandom (version 0.2.10):
   The Rand Project Developers
 
-gimli (version 0.28.0):
-  gimli authors
-
 hashbrown (version 0.12.3):
-  Amanieu d'Antras
+  Amanieu d'Antras <amanieu@gmail.com>
 
 heck (version 0.4.1):
-  Without Boats
+  Without Boats <woboats@gmail.com>
 
 hermit-abi (version 0.3.2):
   Stefan Lankes
 
 is-terminal (version 0.4.9):
-  softprops, Dan Gohman
+  softprops <d.tangren@gmail.com>, Dan Gohman <dev@sunfishcode.online>
 
 itertools (version 0.10.5):
   bluss
@@ -103,142 +79,130 @@ itertools (version 0.11.0):
   bluss
 
 itoa (version 1.0.9):
-  David Tolnay
+  David Tolnay <dtolnay@gmail.com>
 
 lazy_static (version 1.4.0):
-  Marvin Löbel
+  Marvin Löbel <loebel.marvin@gmail.com>
 
 libR-sys (version 0.4.0):
-  andy-thomason, Thomas Down, Mossa Merhi Reimert, Claus O. Wilke, Ilia A. Kosenkov, Hiroaki Yutani
+  andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>, Hiroaki Yutani
 
 libc (version 0.2.147):
   The Rust Project Developers
 
 linux-raw-sys (version 0.4.5):
-  Dan Gohman
+  Dan Gohman <dev@sunfishcode.online>
 
 log (version 0.4.20):
   The Rust Project Developers
 
 memchr (version 2.6.1):
-  Andrew Gallant, bluss
+  Andrew Gallant <jamslam@gmail.com>, bluss
 
 minimal-lexical (version 0.2.1):
-  Alex Huszagh
+  Alex Huszagh <ahuszagh@gmail.com>
 
 miniz_oxide (version 0.7.1):
-  Frommi, oyvindln
+  Frommi <daniil.liferenko@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>
 
 nom (version 7.1.3):
   contact@geoffroycouprie.com
 
-object (version 0.32.0):
-  object authors
-
 once_cell (version 1.18.0):
-  Aleksey Kladov
+  Aleksey Kladov <aleksey.kladov@gmail.com>
 
 paste (version 1.0.14):
-  David Tolnay
+  David Tolnay <dtolnay@gmail.com>
 
 proc-macro2 (version 1.0.66):
-  David Tolnay, Alex Crichton
-
-prql-ast (version 0.9.4):
-  prql-ast authors
-
-prql-compiler (version 0.9.4):
-  prql-compiler authors
-
-prql-parser (version 0.9.4):
-  prql-parser authors
+  David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>
 
 psm (version 0.1.21):
-  Simonas Kazlauskas
+  Simonas Kazlauskas <psm@kazlauskas.me>
 
 quote (version 1.0.33):
-  David Tolnay
+  David Tolnay <dtolnay@gmail.com>
 
 regex (version 1.9.4):
-  The Rust Project Developers, Andrew Gallant
+  The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
 
 regex-automata (version 0.3.7):
-  The Rust Project Developers, Andrew Gallant
+  The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
 
 regex-syntax (version 0.7.5):
-  The Rust Project Developers, Andrew Gallant
+  The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
 
 rustc-demangle (version 0.1.23):
-  Alex Crichton
+  Alex Crichton <alex@alexcrichton.com>
 
 rustix (version 0.38.10):
-  Dan Gohman, Jakub Konka
+  Dan Gohman <dev@sunfishcode.online>, Jakub Konka <kubkon@jakubkonka.com>
 
 rustversion (version 1.0.14):
-  David Tolnay
+  David Tolnay <dtolnay@gmail.com>
 
 ryu (version 1.0.15):
-  David Tolnay
+  David Tolnay <dtolnay@gmail.com>
 
 semver (version 1.0.18):
-  David Tolnay
+  David Tolnay <dtolnay@gmail.com>
 
 serde (version 1.0.188):
-  Erick Tryzelaar, David Tolnay
+  Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 
 serde_derive (version 1.0.188):
-  Erick Tryzelaar, David Tolnay
+  Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 
 serde_json (version 1.0.105):
-  Erick Tryzelaar, David Tolnay
+  Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
 
 sqlformat (version 0.2.1):
-  Josh Holmer
+  Josh Holmer <jholmer.in@gmail.com>
 
 sqlparser (version 0.36.1):
-  Andy Grove
+  Andy Grove <andygrove73@gmail.com>
 
 stacker (version 0.1.15):
-  Alex Crichton, Simonas Kazlauskas
+  Alex Crichton <alex@alexcrichton.com>, Simonas Kazlauskas <stacker@kazlauskas.me>
 
 strum (version 0.25.0):
-  Peter Glotfelty
+  Peter Glotfelty <peter.glotfelty@microsoft.com>
 
 strum_macros (version 0.25.2):
-  Peter Glotfelty
+  Peter Glotfelty <peter.glotfelty@microsoft.com>
 
 syn (version 1.0.109):
-  David Tolnay
+  David Tolnay <dtolnay@gmail.com>
 
 syn (version 2.0.29):
-  David Tolnay
+  David Tolnay <dtolnay@gmail.com>
 
 unicode-ident (version 1.0.11):
-  David Tolnay
+  David Tolnay <dtolnay@gmail.com>
 
 unicode-width (version 0.1.10):
-  kwantam, Manish Goregaokar
+  kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>
 
 unicode_categories (version 0.1.1):
-  Sean Gillespie
+  Sean Gillespie <sean@swgillespie.me>
 
 utf8parse (version 0.2.1):
-  Joe Wilm, Christian Duerr
+  Joe Wilm <joe@jwilm.com>, Christian Duerr <contact@christianduerr.com>
 
 version_check (version 0.9.4):
-  Sergio Benitez
+  Sergio Benitez <sb@sergio.bz>
 
 wasi (version 0.11.0+wasi-snapshot-preview1):
   The Cranelift Project Developers
 
 winapi (version 0.3.9):
-  Peter Atashian
+  Peter Atashian <retep998@gmail.com>
 
 winapi-i686-pc-windows-gnu (version 0.4.0):
-  Peter Atashian
+  Peter Atashian <retep998@gmail.com>
 
 winapi-x86_64-pc-windows-gnu (version 0.4.0):
-  Peter Atashian
+  Peter Atashian <retep998@gmail.com>
 
 windows-sys (version 0.48.0):
   Microsoft
@@ -268,4 +232,4 @@ windows_x86_64_msvc (version 0.48.5):
   Microsoft
 
 yansi (version 0.5.1):
-  Sergio Benitez
+  Sergio Benitez <sb@sergio.bz>

--- a/inst/AUTHORS
+++ b/inst/AUTHORS
@@ -1,235 +1,79 @@
-The authors of the dependency Rust crates:
-
-adler (version 1.0.2):
-  Jonas Schievink <jonasschievink@gmail.com>
-
-ahash (version 0.7.6):
-  Tom Kaitchuck <Tom.Kaitchuck@gmail.com>
-
-aho-corasick (version 1.0.5):
-  Andrew Gallant <jamslam@gmail.com>
-
-anyhow (version 1.0.75):
-  David Tolnay <dtolnay@gmail.com>
-
-ariadne (version 0.3.0):
-  Joshua Barretto <joshua.s.barretto@gmail.com>
-
-backtrace (version 0.3.69):
-  The Rust Project Developers
-
-bitflags (version 2.4.0):
-  The Rust Project Developers
-
-cc (version 1.0.83):
-  Alex Crichton <alex@alexcrichton.com>
-
-cfg-if (version 1.0.0):
-  Alex Crichton <alex@alexcrichton.com>
-
-chumsky (version 0.9.2):
-  Joshua Barretto <joshua.s.barretto@gmail.com>
-
-csv (version 1.2.2):
-  Andrew Gallant <jamslam@gmail.com>
-
-csv-core (version 0.1.10):
-  Andrew Gallant <jamslam@gmail.com>
-
-either (version 1.9.0):
-  bluss
-
-enum-as-inner (version 0.6.0):
-  Benjamin Fry <benjaminfry@me.com>
-
-errno (version 0.3.3):
-  Chris Wong <lambda.fairy@gmail.com>
-
-errno-dragonfly (version 0.1.2):
-  Michael Neumann <mneumann@ntecs.de>
-
-extendr-api (version 0.4.0):
-  andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Hiroaki Yutani, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>, Michael Milton <michael.r.milton@gmail.com>
-
-extendr-engine (version 0.4.0):
-  andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Hiroaki Yutani, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>
-
-extendr-macros (version 0.4.0):
-  andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Hiroaki Yutani, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>
-
-getrandom (version 0.2.10):
-  The Rand Project Developers
-
-hashbrown (version 0.12.3):
-  Amanieu d'Antras <amanieu@gmail.com>
-
-heck (version 0.4.1):
-  Without Boats <woboats@gmail.com>
-
-hermit-abi (version 0.3.2):
-  Stefan Lankes
-
-is-terminal (version 0.4.9):
-  softprops <d.tangren@gmail.com>, Dan Gohman <dev@sunfishcode.online>
-
-itertools (version 0.10.5):
-  bluss
-
-itertools (version 0.11.0):
-  bluss
-
-itoa (version 1.0.9):
-  David Tolnay <dtolnay@gmail.com>
-
-lazy_static (version 1.4.0):
-  Marvin Löbel <loebel.marvin@gmail.com>
-
-libR-sys (version 0.4.0):
-  andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>, Hiroaki Yutani
-
-libc (version 0.2.147):
-  The Rust Project Developers
-
-linux-raw-sys (version 0.4.5):
-  Dan Gohman <dev@sunfishcode.online>
-
-log (version 0.4.20):
-  The Rust Project Developers
-
-memchr (version 2.6.1):
-  Andrew Gallant <jamslam@gmail.com>, bluss
-
-minimal-lexical (version 0.2.1):
-  Alex Huszagh <ahuszagh@gmail.com>
-
-miniz_oxide (version 0.7.1):
-  Frommi <daniil.liferenko@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>
-
-nom (version 7.1.3):
-  contact@geoffroycouprie.com
-
-once_cell (version 1.18.0):
-  Aleksey Kladov <aleksey.kladov@gmail.com>
-
-paste (version 1.0.14):
-  David Tolnay <dtolnay@gmail.com>
-
-proc-macro2 (version 1.0.66):
-  David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>
-
-psm (version 0.1.21):
-  Simonas Kazlauskas <psm@kazlauskas.me>
-
-quote (version 1.0.33):
-  David Tolnay <dtolnay@gmail.com>
-
-regex (version 1.9.4):
-  The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
-
-regex-automata (version 0.3.7):
-  The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
-
-regex-syntax (version 0.7.5):
-  The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
-
-rustc-demangle (version 0.1.23):
-  Alex Crichton <alex@alexcrichton.com>
-
-rustix (version 0.38.10):
-  Dan Gohman <dev@sunfishcode.online>, Jakub Konka <kubkon@jakubkonka.com>
-
-rustversion (version 1.0.14):
-  David Tolnay <dtolnay@gmail.com>
-
-ryu (version 1.0.15):
-  David Tolnay <dtolnay@gmail.com>
-
-semver (version 1.0.18):
-  David Tolnay <dtolnay@gmail.com>
-
-serde (version 1.0.188):
-  Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
-
-serde_derive (version 1.0.188):
-  Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
-
-serde_json (version 1.0.105):
-  Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
-
-sqlformat (version 0.2.1):
-  Josh Holmer <jholmer.in@gmail.com>
-
-sqlparser (version 0.36.1):
-  Andy Grove <andygrove73@gmail.com>
-
-stacker (version 0.1.15):
-  Alex Crichton <alex@alexcrichton.com>, Simonas Kazlauskas <stacker@kazlauskas.me>
-
-strum (version 0.25.0):
-  Peter Glotfelty <peter.glotfelty@microsoft.com>
-
-strum_macros (version 0.25.2):
-  Peter Glotfelty <peter.glotfelty@microsoft.com>
-
-syn (version 1.0.109):
-  David Tolnay <dtolnay@gmail.com>
-
-syn (version 2.0.29):
-  David Tolnay <dtolnay@gmail.com>
-
-unicode-ident (version 1.0.11):
-  David Tolnay <dtolnay@gmail.com>
-
-unicode-width (version 0.1.10):
-  kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>
-
-unicode_categories (version 0.1.1):
-  Sean Gillespie <sean@swgillespie.me>
-
-utf8parse (version 0.2.1):
-  Joe Wilm <joe@jwilm.com>, Christian Duerr <contact@christianduerr.com>
-
-version_check (version 0.9.4):
-  Sergio Benitez <sb@sergio.bz>
-
-wasi (version 0.11.0+wasi-snapshot-preview1):
-  The Cranelift Project Developers
-
-winapi (version 0.3.9):
-  Peter Atashian <retep998@gmail.com>
-
-winapi-i686-pc-windows-gnu (version 0.4.0):
-  Peter Atashian <retep998@gmail.com>
-
-winapi-x86_64-pc-windows-gnu (version 0.4.0):
-  Peter Atashian <retep998@gmail.com>
-
-windows-sys (version 0.48.0):
-  Microsoft
-
-windows-targets (version 0.48.5):
-  Microsoft
-
-windows_aarch64_gnullvm (version 0.48.5):
-  Microsoft
-
-windows_aarch64_msvc (version 0.48.5):
-  Microsoft
-
-windows_i686_gnu (version 0.48.5):
-  Microsoft
-
-windows_i686_msvc (version 0.48.5):
-  Microsoft
-
-windows_x86_64_gnu (version 0.48.5):
-  Microsoft
-
-windows_x86_64_gnullvm (version 0.48.5):
-  Microsoft
-
-windows_x86_64_msvc (version 0.48.5):
-  Microsoft
-
-yansi (version 0.5.1):
-  Sergio Benitez <sb@sergio.bz>
+Authors of dependent Rust crates:
+  - adler (version 1.0.2): Jonas Schievink <jonasschievink@gmail.com>
+  - ahash (version 0.7.6): Tom Kaitchuck <Tom.Kaitchuck@gmail.com>
+  - aho-corasick (version 1.0.5): Andrew Gallant <jamslam@gmail.com>
+  - anyhow (version 1.0.75): David Tolnay <dtolnay@gmail.com>
+  - ariadne (version 0.3.0): Joshua Barretto <joshua.s.barretto@gmail.com>
+  - backtrace (version 0.3.69): The Rust Project Developers
+  - bitflags (version 2.4.0): The Rust Project Developers
+  - cc (version 1.0.83): Alex Crichton <alex@alexcrichton.com>
+  - cfg-if (version 1.0.0): Alex Crichton <alex@alexcrichton.com>
+  - chumsky (version 0.9.2): Joshua Barretto <joshua.s.barretto@gmail.com>
+  - csv (version 1.2.2): Andrew Gallant <jamslam@gmail.com>
+  - csv-core (version 0.1.10): Andrew Gallant <jamslam@gmail.com>
+  - either (version 1.9.0): bluss
+  - enum-as-inner (version 0.6.0): Benjamin Fry <benjaminfry@me.com>
+  - errno (version 0.3.3): Chris Wong <lambda.fairy@gmail.com>
+  - errno-dragonfly (version 0.1.2): Michael Neumann <mneumann@ntecs.de>
+  - extendr-api (version 0.4.0): andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Hiroaki Yutani, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>, Michael Milton <michael.r.milton@gmail.com>
+  - extendr-engine (version 0.4.0): andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Hiroaki Yutani, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>
+  - extendr-macros (version 0.4.0): andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Hiroaki Yutani, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>
+  - getrandom (version 0.2.10): The Rand Project Developers
+  - hashbrown (version 0.12.3): Amanieu d'Antras <amanieu@gmail.com>
+  - heck (version 0.4.1): Without Boats <woboats@gmail.com>
+  - hermit-abi (version 0.3.2): Stefan Lankes
+  - is-terminal (version 0.4.9): softprops <d.tangren@gmail.com>, Dan Gohman <dev@sunfishcode.online>
+  - itertools (version 0.10.5): bluss
+  - itertools (version 0.11.0): bluss
+  - itoa (version 1.0.9): David Tolnay <dtolnay@gmail.com>
+  - lazy_static (version 1.4.0): Marvin Löbel <loebel.marvin@gmail.com>
+  - libR-sys (version 0.4.0): andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>, Hiroaki Yutani
+  - libc (version 0.2.147): The Rust Project Developers
+  - linux-raw-sys (version 0.4.5): Dan Gohman <dev@sunfishcode.online>
+  - log (version 0.4.20): The Rust Project Developers
+  - memchr (version 2.6.1): Andrew Gallant <jamslam@gmail.com>, bluss
+  - minimal-lexical (version 0.2.1): Alex Huszagh <ahuszagh@gmail.com>
+  - miniz_oxide (version 0.7.1): Frommi <daniil.liferenko@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>
+  - nom (version 7.1.3): contact@geoffroycouprie.com
+  - once_cell (version 1.18.0): Aleksey Kladov <aleksey.kladov@gmail.com>
+  - paste (version 1.0.14): David Tolnay <dtolnay@gmail.com>
+  - proc-macro2 (version 1.0.66): David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>
+  - psm (version 0.1.21): Simonas Kazlauskas <psm@kazlauskas.me>
+  - quote (version 1.0.33): David Tolnay <dtolnay@gmail.com>
+  - regex (version 1.9.4): The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
+  - regex-automata (version 0.3.7): The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
+  - regex-syntax (version 0.7.5): The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
+  - rustc-demangle (version 0.1.23): Alex Crichton <alex@alexcrichton.com>
+  - rustix (version 0.38.10): Dan Gohman <dev@sunfishcode.online>, Jakub Konka <kubkon@jakubkonka.com>
+  - rustversion (version 1.0.14): David Tolnay <dtolnay@gmail.com>
+  - ryu (version 1.0.15): David Tolnay <dtolnay@gmail.com>
+  - semver (version 1.0.18): David Tolnay <dtolnay@gmail.com>
+  - serde (version 1.0.188): Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
+  - serde_derive (version 1.0.188): Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
+  - serde_json (version 1.0.105): Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
+  - sqlformat (version 0.2.1): Josh Holmer <jholmer.in@gmail.com>
+  - sqlparser (version 0.36.1): Andy Grove <andygrove73@gmail.com>
+  - stacker (version 0.1.15): Alex Crichton <alex@alexcrichton.com>, Simonas Kazlauskas <stacker@kazlauskas.me>
+  - strum (version 0.25.0): Peter Glotfelty <peter.glotfelty@microsoft.com>
+  - strum_macros (version 0.25.2): Peter Glotfelty <peter.glotfelty@microsoft.com>
+  - syn (version 1.0.109): David Tolnay <dtolnay@gmail.com>
+  - syn (version 2.0.29): David Tolnay <dtolnay@gmail.com>
+  - unicode-ident (version 1.0.11): David Tolnay <dtolnay@gmail.com>
+  - unicode-width (version 0.1.10): kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>
+  - unicode_categories (version 0.1.1): Sean Gillespie <sean@swgillespie.me>
+  - utf8parse (version 0.2.1): Joe Wilm <joe@jwilm.com>, Christian Duerr <contact@christianduerr.com>
+  - version_check (version 0.9.4): Sergio Benitez <sb@sergio.bz>
+  - wasi (version 0.11.0+wasi-snapshot-preview1): The Cranelift Project Developers
+  - winapi (version 0.3.9): Peter Atashian <retep998@gmail.com>
+  - winapi-i686-pc-windows-gnu (version 0.4.0): Peter Atashian <retep998@gmail.com>
+  - winapi-x86_64-pc-windows-gnu (version 0.4.0): Peter Atashian <retep998@gmail.com>
+  - windows-sys (version 0.48.0): Microsoft
+  - windows-targets (version 0.48.5): Microsoft
+  - windows_aarch64_gnullvm (version 0.48.5): Microsoft
+  - windows_aarch64_msvc (version 0.48.5): Microsoft
+  - windows_i686_gnu (version 0.48.5): Microsoft
+  - windows_i686_msvc (version 0.48.5): Microsoft
+  - windows_x86_64_gnu (version 0.48.5): Microsoft
+  - windows_x86_64_gnullvm (version 0.48.5): Microsoft
+  - windows_x86_64_msvc (version 0.48.5): Microsoft
+  - yansi (version 0.5.1): Sergio Benitez <sb@sergio.bz>


### PR DESCRIPTION
Related to #168
Addressing an email received after the first submission of prqlr 0.5.2 (#167).

> Thanks, we see:
>
>
>      person(given = "The authors of the dependency Rust crates", role = c("aut"),
>             comment = "see inst/AUTHORS file for details"))
>
> is not acceptable, especially as the file has things like
>
>
> ```
> addr2line (version 0.21.0):
>   addr2line authors
>
> anstyle (version 1.0.2):
>   anstyle authors
>
> anstyle-parse (version 0.2.1):
>   anstyle-parse authors
>
> anstyle-query (version 1.0.0):
>   anstyle-query authors
>
> anstyle-wincon (version 1.0.2):
>   anstyle-wincon authors
>
> is-terminal (version 0.4.9):
>   softprops, Dan Gohman
>
> itertools (version 0.10.5):
>   bluss
>
> itertools (version 0.11.0):
>   bluss
> ```
>
>
> Please fix and resubmit.

However, looking at the AUTHORS file in the existing packages on CRAN, there does not seem to be a specific format, and I am not sure what format would be accepted by CRAN.

At first, I excluded crates with no `package.authors` set from the list.