### PR TITLE
docs: update AUTHORS format

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Miscellaneous
 
-- Update the `Authors` field of the DESCRIPTION file and the `inst/AUTHORS` file's format. (#169)
+- Update the `Authors` field of the DESCRIPTION file and the `inst/AUTHORS` file's format. (#169, #172)
 
 # prqlr 0.5.1
 

--- a/dev/generate-authors.R
+++ b/dev/generate-authors.R
@@ -2,16 +2,7 @@ write_authors <- function(path = ".", quiet = FALSE, force = TRUE) {
   manifest_file <- rprojroot::find_package_root_file("src", "rust", "Cargo.toml", path = path)
   outfile <- rprojroot::find_package_root_file("inst", "AUTHORS", path = path)
 
-  list_authors <- processx::run(
-    "cargo",
-    c(
-      "license",
-      "--authors",
-      "--json",
-      "--manifest-path", manifest_file
-    )
-  )$stdout |>
-    jsonlite::parse_json()
+  gh_base_url <- "https://github.com/"
 
   package_names <- processx::run(
     "cargo",
@@ -26,21 +17,66 @@ write_authors <- function(path = ".", quiet = FALSE, force = TRUE) {
     purrr::pluck("packages") |>
     purrr::map_chr("name")
 
-  .prep_authors <- function(authors) {
-    stringi::stri_replace_all_regex(authors, r"(\|)", ", ")
-  }
-
-  authors_header <- "Authors of dependent Rust crates:"
-
-  authors_body <- list_authors |>
-    purrr::discard(function(x) x$name %in% package_names || is.null(x$authors)) |>
-    purrr::map_chr(
-      function(x) {
-        paste0(
-          "  - ", x$name, " (version ", x$version, "): ", .prep_authors(x$authors)
-        )
-      }
+  dep_crates <- processx::run(
+    "cargo",
+    c(
+      "license",
+      "--json",
+      "--manifest-path", manifest_file
     )
+  )$stdout |>
+    jsonlite::parse_json() |>
+    tibble::as_tibble_col() |>
+    tidyr::unnest_wider(value) |>
+    dplyr::filter(!name %in% package_names) |>
+    dplyr::pull(name) |>
+    unique()
+
+  authors_header <- "Owners of dependent Rust crates. This list is generated from Crates.io Data <https://crates.io/data-access>:"
+
+  .old_wd <- getwd()
+  .wd <- withr::local_tempdir()
+  withr::local_dir(.wd)
+
+  dump_file <- "db-dump.tar.gz"
+  exdir <- "db-dump"
+
+  curl::curl_download("https://static.crates.io/db-dump.tar.gz", dump_file)
+  utils::untar(dump_file, exdir = "db-dump")
+
+  withr::local_dir(fs::dir_ls(exdir))
+
+  withr::local_options(list(readr.show_progress = FALSE, readr.show_col_types = FALSE))
+  df_owners <- readr::read_csv("data/crate_owners.csv")
+  df_crates <- readr::read_csv("data/crates.csv", col_types = list(max_upload_size = readr::col_integer()))
+  df_users <- readr::read_csv("data/users.csv")
+
+  df_owner_names <- df_crates |>
+    dplyr::filter(name %in% dep_crates) |>
+    dplyr::select(crate_id = id, crate_name = name) |>
+    dplyr::left_join(
+      df_owners |>
+        dplyr::select(crate_id, owner_id),
+      by = c("crate_id")
+    ) |>
+    dplyr::left_join(
+      df_users |>
+        dplyr::select(id, name, gh_login),
+      by = c("owner_id" = "id")
+    ) |>
+    dplyr::arrange("owner_id") |>
+    dplyr::mutate(
+      name = stringr::str_c(name, " <", gh_base_url, gh_login, ">"),
+      .keep = "unused"
+    ) |>
+    dplyr::filter(!dplyr::if_any(tidyselect::everything(), is.na)) |>
+    dplyr::summarise(names = stringr::str_c(name, collapse = ", "), .by = crate_name) |>
+    dplyr::arrange(crate_name)
+
+  authors_body <- df_owner_names |>
+    purrr::pmap_chr(\(crate_name, names) stringr::str_c("  - ", crate_name, ": ", names))
+
+  withr::local_dir(.old_wd)
 
   rextendr:::write_file(
     text = c(authors_header, authors_body),

--- a/inst/AUTHORS
+++ b/inst/AUTHORS
@@ -1,79 +1,88 @@
-Authors of dependent Rust crates:
-  - adler (version 1.0.2): Jonas Schievink <jonasschievink@gmail.com>
-  - ahash (version 0.7.6): Tom Kaitchuck <Tom.Kaitchuck@gmail.com>
-  - aho-corasick (version 1.0.5): Andrew Gallant <jamslam@gmail.com>
-  - anyhow (version 1.0.75): David Tolnay <dtolnay@gmail.com>
-  - ariadne (version 0.3.0): Joshua Barretto <joshua.s.barretto@gmail.com>
-  - backtrace (version 0.3.69): The Rust Project Developers
-  - bitflags (version 2.4.0): The Rust Project Developers
-  - cc (version 1.0.83): Alex Crichton <alex@alexcrichton.com>
-  - cfg-if (version 1.0.0): Alex Crichton <alex@alexcrichton.com>
-  - chumsky (version 0.9.2): Joshua Barretto <joshua.s.barretto@gmail.com>
-  - csv (version 1.2.2): Andrew Gallant <jamslam@gmail.com>
-  - csv-core (version 0.1.10): Andrew Gallant <jamslam@gmail.com>
-  - either (version 1.9.0): bluss
-  - enum-as-inner (version 0.6.0): Benjamin Fry <benjaminfry@me.com>
-  - errno (version 0.3.3): Chris Wong <lambda.fairy@gmail.com>
-  - errno-dragonfly (version 0.1.2): Michael Neumann <mneumann@ntecs.de>
-  - extendr-api (version 0.4.0): andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Hiroaki Yutani, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>, Michael Milton <michael.r.milton@gmail.com>
-  - extendr-engine (version 0.4.0): andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Hiroaki Yutani, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>
-  - extendr-macros (version 0.4.0): andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Hiroaki Yutani, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>
-  - getrandom (version 0.2.10): The Rand Project Developers
-  - hashbrown (version 0.12.3): Amanieu d'Antras <amanieu@gmail.com>
-  - heck (version 0.4.1): Without Boats <woboats@gmail.com>
-  - hermit-abi (version 0.3.2): Stefan Lankes
-  - is-terminal (version 0.4.9): softprops <d.tangren@gmail.com>, Dan Gohman <dev@sunfishcode.online>
-  - itertools (version 0.10.5): bluss
-  - itertools (version 0.11.0): bluss
-  - itoa (version 1.0.9): David Tolnay <dtolnay@gmail.com>
-  - lazy_static (version 1.4.0): Marvin Löbel <loebel.marvin@gmail.com>
-  - libR-sys (version 0.4.0): andy-thomason <andy@andythomason.com>, Thomas Down, Mossa Merhi Reimert <mossa@sund.ku.dk>, Claus O. Wilke <wilke@austin.utexas.edu>, Ilia A. Kosenkov <ilia.kosenkov@outlook.com>, Hiroaki Yutani
-  - libc (version 0.2.147): The Rust Project Developers
-  - linux-raw-sys (version 0.4.5): Dan Gohman <dev@sunfishcode.online>
-  - log (version 0.4.20): The Rust Project Developers
-  - memchr (version 2.6.1): Andrew Gallant <jamslam@gmail.com>, bluss
-  - minimal-lexical (version 0.2.1): Alex Huszagh <ahuszagh@gmail.com>
-  - miniz_oxide (version 0.7.1): Frommi <daniil.liferenko@gmail.com>, oyvindln <oyvindln@users.noreply.github.com>
-  - nom (version 7.1.3): contact@geoffroycouprie.com
-  - once_cell (version 1.18.0): Aleksey Kladov <aleksey.kladov@gmail.com>
-  - paste (version 1.0.14): David Tolnay <dtolnay@gmail.com>
-  - proc-macro2 (version 1.0.66): David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>
-  - psm (version 0.1.21): Simonas Kazlauskas <psm@kazlauskas.me>
-  - quote (version 1.0.33): David Tolnay <dtolnay@gmail.com>
-  - regex (version 1.9.4): The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
-  - regex-automata (version 0.3.7): The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
-  - regex-syntax (version 0.7.5): The Rust Project Developers, Andrew Gallant <jamslam@gmail.com>
-  - rustc-demangle (version 0.1.23): Alex Crichton <alex@alexcrichton.com>
-  - rustix (version 0.38.10): Dan Gohman <dev@sunfishcode.online>, Jakub Konka <kubkon@jakubkonka.com>
-  - rustversion (version 1.0.14): David Tolnay <dtolnay@gmail.com>
-  - ryu (version 1.0.15): David Tolnay <dtolnay@gmail.com>
-  - semver (version 1.0.18): David Tolnay <dtolnay@gmail.com>
-  - serde (version 1.0.188): Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
-  - serde_derive (version 1.0.188): Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
-  - serde_json (version 1.0.105): Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>
-  - sqlformat (version 0.2.1): Josh Holmer <jholmer.in@gmail.com>
-  - sqlparser (version 0.36.1): Andy Grove <andygrove73@gmail.com>
-  - stacker (version 0.1.15): Alex Crichton <alex@alexcrichton.com>, Simonas Kazlauskas <stacker@kazlauskas.me>
-  - strum (version 0.25.0): Peter Glotfelty <peter.glotfelty@microsoft.com>
-  - strum_macros (version 0.25.2): Peter Glotfelty <peter.glotfelty@microsoft.com>
-  - syn (version 1.0.109): David Tolnay <dtolnay@gmail.com>
-  - syn (version 2.0.29): David Tolnay <dtolnay@gmail.com>
-  - unicode-ident (version 1.0.11): David Tolnay <dtolnay@gmail.com>
-  - unicode-width (version 0.1.10): kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>
-  - unicode_categories (version 0.1.1): Sean Gillespie <sean@swgillespie.me>
-  - utf8parse (version 0.2.1): Joe Wilm <joe@jwilm.com>, Christian Duerr <contact@christianduerr.com>
-  - version_check (version 0.9.4): Sergio Benitez <sb@sergio.bz>
-  - wasi (version 0.11.0+wasi-snapshot-preview1): The Cranelift Project Developers
-  - winapi (version 0.3.9): Peter Atashian <retep998@gmail.com>
-  - winapi-i686-pc-windows-gnu (version 0.4.0): Peter Atashian <retep998@gmail.com>
-  - winapi-x86_64-pc-windows-gnu (version 0.4.0): Peter Atashian <retep998@gmail.com>
-  - windows-sys (version 0.48.0): Microsoft
-  - windows-targets (version 0.48.5): Microsoft
-  - windows_aarch64_gnullvm (version 0.48.5): Microsoft
-  - windows_aarch64_msvc (version 0.48.5): Microsoft
-  - windows_i686_gnu (version 0.48.5): Microsoft
-  - windows_i686_msvc (version 0.48.5): Microsoft
-  - windows_x86_64_gnu (version 0.48.5): Microsoft
-  - windows_x86_64_gnullvm (version 0.48.5): Microsoft
-  - windows_x86_64_msvc (version 0.48.5): Microsoft
-  - yansi (version 0.5.1): Sergio Benitez <sb@sergio.bz>
+Owners of dependent Rust crates. This list is generated from Crates.io Data <https://crates.io/data-access>:
+  - addr2line: Nick Fitzgerald <https://github.com/fitzgen>, Philip Craig <https://github.com/philipc>
+  - adler: Jonas Schievink <https://github.com/jonas-schievink>
+  - ahash: Tom Kaitchuck <https://github.com/tkaitchuck>
+  - aho-corasick: Andrew Gallant <https://github.com/BurntSushi>
+  - anstream: Ed Page <https://github.com/epage>
+  - anstyle: Ed Page <https://github.com/epage>
+  - anstyle-parse: Ed Page <https://github.com/epage>
+  - anstyle-query: Ed Page <https://github.com/epage>
+  - anstyle-wincon: Ed Page <https://github.com/epage>
+  - anyhow: David Tolnay <https://github.com/dtolnay>
+  - ariadne: Joshua Barretto <https://github.com/zesterer>
+  - backtrace: ember arlynx <https://github.com/emberian>, Alex Crichton <https://github.com/alexcrichton>
+  - bitflags: Huon Wilson <https://github.com/huonw>, Alex Crichton <https://github.com/alexcrichton>, Ashley Mannix <https://github.com/KodrAus>
+  - cc: ember arlynx <https://github.com/emberian>
+  - cfg-if: ember arlynx <https://github.com/emberian>, Alex Crichton <https://github.com/alexcrichton>
+  - chumsky: Joshua Barretto <https://github.com/zesterer>
+  - colorchoice: Ed Page <https://github.com/epage>
+  - csv: Andrew Gallant <https://github.com/BurntSushi>
+  - csv-core: Andrew Gallant <https://github.com/BurntSushi>
+  - either: bluss <https://github.com/bluss>, Josh Stone <https://github.com/cuviper>
+  - enum-as-inner: Benjamin Fry <https://github.com/bluejekyll>
+  - errno: Chris Wong <https://github.com/lambda-fairy>, Dan Gohman <https://github.com/sunfishcode>
+  - errno-dragonfly: Michael Neumann <https://github.com/mneumann>
+  - extendr-api: Andy Thomson <https://github.com/andy-thomason>, Claus Wilke <https://github.com/clauswilke>, Hiroaki Yutani <https://github.com/yutannihilation>, Michael Milton <https://github.com/multimeric>, Ilia Kosenkov <https://github.com/Ilia-Kosenkov>
+  - extendr-engine: Claus Wilke <https://github.com/clauswilke>, Andy Thomson <https://github.com/andy-thomason>, Hiroaki Yutani <https://github.com/yutannihilation>, Michael Milton <https://github.com/multimeric>, Ilia Kosenkov <https://github.com/Ilia-Kosenkov>
+  - extendr-macros: Andy Thomson <https://github.com/andy-thomason>, Claus Wilke <https://github.com/clauswilke>, Hiroaki Yutani <https://github.com/yutannihilation>, Michael Milton <https://github.com/multimeric>, Ilia Kosenkov <https://github.com/Ilia-Kosenkov>
+  - getrandom: Diggory Hardy <https://github.com/dhardy>
+  - gimli: Nick Fitzgerald <https://github.com/fitzgen>, Philip Craig <https://github.com/philipc>
+  - hashbrown: Amanieu d'Antras <https://github.com/Amanieu>
+  - heck: Saoirse Shipwreckt <https://github.com/withoutboats>, Jonas Platte <https://github.com/jplatte>
+  - hermit-abi: Stefan Lankes <https://github.com/stlankes>, Martin Kröning <https://github.com/mkroening>
+  - is-terminal: Dan Gohman <https://github.com/sunfishcode>
+  - itertools: bluss <https://github.com/bluss>, Jack Wrenn <https://github.com/jswrenn>
+  - itoa: David Tolnay <https://github.com/dtolnay>
+  - lazy_static: Marvin Löbel <https://github.com/Kimundi>
+  - libR-sys: Andy Thomson <https://github.com/andy-thomason>, Claus Wilke <https://github.com/clauswilke>, Hiroaki Yutani <https://github.com/yutannihilation>, Michael Milton <https://github.com/multimeric>, Ilia Kosenkov <https://github.com/Ilia-Kosenkov>
+  - libc: Huon Wilson <https://github.com/huonw>, ember arlynx <https://github.com/emberian>, gnzlbg <https://github.com/gnzlbg>, Yuki Okushi <https://github.com/JohnTitor>, Alex Crichton <https://github.com/alexcrichton>, Josh Triplett <https://github.com/joshtriplett>, Sebastian Dröge <https://github.com/sdroege>
+  - linux-raw-sys: Dan Gohman <https://github.com/sunfishcode>
+  - log: Huon Wilson <https://github.com/huonw>, Steven Fackler <https://github.com/sfackler>, Alex Crichton <https://github.com/alexcrichton>, Ashley Mannix <https://github.com/KodrAus>
+  - memchr: Andrew Gallant <https://github.com/BurntSushi>
+  - minimal-lexical: Alexander Huszagh <https://github.com/Alexhuszagh>
+  - nom: Geoffroy Couprie <https://github.com/Geal>
+  - object: Nick Fitzgerald <https://github.com/fitzgen>, Philip Craig <https://github.com/philipc>
+  - once_cell: Alex Kladov <https://github.com/matklad>, Michal 'vorner' Vaner <https://github.com/vorner>
+  - paste: David Tolnay <https://github.com/dtolnay>
+  - proc-macro2: David Tolnay <https://github.com/dtolnay>
+  - prql-ast: Maximilian Roos <https://github.com/max-sixty>
+  - prql-compiler: Maximilian Roos <https://github.com/max-sixty>
+  - prql-parser: Maximilian Roos <https://github.com/max-sixty>
+  - psm: Simonas Kazlauskas <https://github.com/nagisa>
+  - quote: David Tolnay <https://github.com/dtolnay>
+  - regex: Andrew Gallant <https://github.com/BurntSushi>, ember arlynx <https://github.com/emberian>, Alex Crichton <https://github.com/alexcrichton>
+  - regex-automata: Andrew Gallant <https://github.com/BurntSushi>
+  - regex-syntax: Andrew Gallant <https://github.com/BurntSushi>, Alex Crichton <https://github.com/alexcrichton>, ember arlynx <https://github.com/emberian>
+  - rustc-demangle: Alex Crichton <https://github.com/alexcrichton>
+  - rustix: Dan Gohman <https://github.com/sunfishcode>
+  - rustversion: David Tolnay <https://github.com/dtolnay>
+  - ryu: David Tolnay <https://github.com/dtolnay>
+  - semver: David Tolnay <https://github.com/dtolnay>
+  - serde: David Tolnay <https://github.com/dtolnay>
+  - serde_derive: David Tolnay <https://github.com/dtolnay>
+  - serde_json: David Tolnay <https://github.com/dtolnay>
+  - sqlformat: Josh Holmer <https://github.com/shssoichiro>
+  - sqlparser: Andy Grove <https://github.com/andygrove>, Daniël Heres <https://github.com/Dandandan>, Max Countryman <https://github.com/maxcountryman>, Nickolay Ponomarev <https://github.com/nickolay>, Andrew Lamb <https://github.com/alamb>
+  - stacker: Simonas Kazlauskas <https://github.com/nagisa>, Alex Crichton <https://github.com/alexcrichton>
+  - strum: Peter Glotfelty <https://github.com/Peternator7>
+  - strum_macros: Peter Glotfelty <https://github.com/Peternator7>
+  - syn: David Tolnay <https://github.com/dtolnay>
+  - unicode-ident: David Tolnay <https://github.com/dtolnay>
+  - unicode-width: Riad S. Wahby <https://github.com/kwantam>, Huon Wilson <https://github.com/huonw>, Simon Sapin <https://github.com/SimonSapin>, Manish Goregaokar <https://github.com/Manishearth>, Sujay Jayakar <https://github.com/sujayakar>, Alex Crichton <https://github.com/alexcrichton>
+  - unicode_categories: Sean Gillespie <https://github.com/swgillespie>
+  - utf8parse: Joe Wilm <https://github.com/jwilm>, Christian Duerr <https://github.com/chrisduerr>, Tyler Berry <https://github.com/Tahler>
+  - version_check: Sergio Benitez <https://github.com/SergioBenitez>
+  - wasi: Dan Gohman <https://github.com/sunfishcode>, Alex Crichton <https://github.com/alexcrichton>
+  - winapi: Peter Atashian <https://github.com/retep998>
+  - winapi-i686-pc-windows-gnu: Peter Atashian <https://github.com/retep998>
+  - winapi-x86_64-pc-windows-gnu: Peter Atashian <https://github.com/retep998>
+  - windows-sys: Kenny Kerr <https://github.com/kennykerr>
+  - windows-targets: Kenny Kerr <https://github.com/kennykerr>
+  - windows_aarch64_gnullvm: Kenny Kerr <https://github.com/kennykerr>
+  - windows_aarch64_msvc: Kenny Kerr <https://github.com/kennykerr>
+  - windows_i686_gnu: Kenny Kerr <https://github.com/kennykerr>
+  - windows_i686_msvc: Kenny Kerr <https://github.com/kennykerr>
+  - windows_x86_64_gnu: Kenny Kerr <https://github.com/kennykerr>
+  - windows_x86_64_gnullvm: Kenny Kerr <https://github.com/kennykerr>
+  - windows_x86_64_msvc: Kenny Kerr <https://github.com/kennykerr>
+  - yansi: Sergio Benitez <https://github.com/SergioBenitez>


### PR DESCRIPTION
Addressing an email received after the second submission of prqlr 0.5.2 (171).

> Thanks, we see this still has things like
>
>
>   - either (version 1.9.0): bluss
>
> Who or what is 'bluss'?
>
>    - wasi (version 0.11.0+wasi-snapshot-preview1): The Cranelift Project Developers
>
>
> What is that? Seems a project that has changed its name recently, so needs clarification.
>
> We really need to see the authors and copyright holders.
> As you include their code, they hold partial copyright on your package. Even if the rust people seem to be relaxed, we want to know who holds copyright on the software we distribute. And we believe one has to decalre this cleanly.

Lists the owner of each crate registered on Crates.io.