### PR TITLE
chore: remove the internal function `.get_engine_opt` in favor of the new feature of knitr 1.44

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ BugReports: https://github.com/eitsupi/prqlr/issues
 Depends:
     R (>= 4.2)
 Suggests:
-    knitr (>= 1.38),
+    knitr (>= 1.44),
     rmarkdown,
     DBI,
     glue,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # prqlr (development version)
 
+## Miscellaneous
+
+- `prql` knitr engine requires `{knitr}` 1.44 or later. (#175)
+
 # prqlr 0.5.2
 
 ## Miscellaneous

--- a/R/knitr-engine.R
+++ b/R/knitr-engine.R
@@ -19,12 +19,12 @@ eng_prql <- function(options) {
     return(knitr::engine_output(options, prql_code, ""))
   }
 
-  if (.get_engine_opt(options, "use_glue", FALSE)) {
+  if (options$engine.opts[["use_glue"]] %||% FALSE) {
     prql_code <- glue::glue(prql_code, .open = "{{", .close = "}}", .envir = knitr::knit_global())
   }
 
-  target <- .get_engine_opt(options, "target", getOption("prqlr.target"))
-  signature_comment <- .get_engine_opt(options, "signature_comment", getOption("prqlr.signature_comment", TRUE))
+  target <- options$engine.opts[["target"]] %||% getOption("prqlr.target")
+  signature_comment <- options$engine.opts[["signature_comment"]] %||% getOption("prqlr.signature_comment", TRUE)
 
   sql_code <- prql_code |>
     prql_compile(target = target, format = TRUE, signature_comment = signature_comment)
@@ -33,7 +33,7 @@ eng_prql <- function(options) {
   if (is.null(options$connection)) {
     options$comment <- ""
     options$results <- "asis"
-    info_string <- .get_engine_opt(options, "info_string", "sql")
+    info_string <- options$engine.opts[["info_string"]] %||% "sql"
 
     out <- paste0(
       "```", info_string, "\n",
@@ -48,13 +48,4 @@ eng_prql <- function(options) {
 
   knitr::knit_engines$get("sql")(options) |>
     sub(sql_code, prql_code, x = _, fixed = TRUE)
-}
-
-#' Get knitr engine options value or default value
-#' @param options a list, knitr options.
-#' @param opt_name the name of target engine option.
-#' @param default the default value of the engine option.
-#' @noRd
-.get_engine_opt <- function(options, opt_name, default = NULL) {
-  options$`engine-opts`[[opt_name]] %||% options$engine.opts[[opt_name]] %||% default
 }


### PR DESCRIPTION
Close #174