### PR TITLE
build(installation): allow installing with pre compiled libraries

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,4 +15,4 @@
 ^\.task$
 ^src/\.cargo$
 ^src/rust/vendor$
-^tools/lib$
+^tools/libprqlr\.a$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^\.task$
 ^src/\.cargo$
 ^src/rust/vendor$
+^tools/lib$

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ docs
 
 src/rust/vendor
 src/rust/vendor.tar.xz
-tools/lib
+tools/libprqlr.a

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs
 
 src/rust/vendor
 src/rust/vendor.tar.xz
+tools/lib

--- a/configure
+++ b/configure
@@ -2,7 +2,8 @@
 
 export PATH="$PATH:$HOME/.cargo/bin"
 
-if [ ! "$(command -v cargo)" ]; then
+check_cargo() {
+  if [ ! "$(command -v cargo)" ]; then
     echo "----------------------- [RUST NOT FOUND]---------------------------"
     echo "The 'cargo' command was not found on the PATH. Please install rustc"
     echo "from: https://www.rust-lang.org/tools/install"
@@ -14,6 +15,9 @@ if [ ! "$(command -v cargo)" ]; then
     echo "-------------------------------------------------------------------"
     echo ""
     exit 1
-fi
+  fi
+}
+
+check_cargo
 
 exit 0

--- a/configure.win
+++ b/configure.win
@@ -2,13 +2,17 @@
 
 export PATH="$PATH:$HOME/.cargo/bin"
 
-if [ ! "$(command -v cargo)" ]; then
+check_cargo() {
+  if [ ! "$(command -v cargo)" ]; then
     echo "----------------------- [RUST NOT FOUND]---------------------------"
     echo "The 'cargo' command was not found on the PATH. Please install rustc"
     echo "from: https://www.rust-lang.org/tools/install"
     echo "-------------------------------------------------------------------"
     echo ""
     exit 1
-fi
+  fi
+}
+
+check_cargo
 
 exit 0

--- a/src/Makevars
+++ b/src/Makevars
@@ -15,16 +15,17 @@ CARGOTMP = $(CURDIR)/.cargo
 VENDOR_DIR = $(CURDIR)/rust/vendor
 
 $(STATLIB):
+	if [ -f "$(CURDIR)/../tools/lib" ]; then \
+		mkdir -p "$(LIBDIR)" ; \
+		mv "$(CURDIR)/../tools/lib" "$(STATLIB)" ; \
+		exit 0; \
+	fi && \
 	if [ -f "$(CURDIR)/rust/vendor.tar.xz" ]; then \
 		mkdir -p "$(VENDOR_DIR)" && \
 		$(TAR) --extract --xz --file "$(CURDIR)/rust/vendor.tar.xz" -C "$(VENDOR_DIR)" && \
 		mkdir -p "$(CARGOTMP)" && \
 		cp "$(CURDIR)/rust/vendor-config.toml" "$(CARGOTMP)/config.toml"; \
-	fi
-
-	# In some environments, ~/.cargo/bin might not be included in PATH, so we need
-	# to set it here to ensure cargo can be invoked. It is appended to PATH and
-	# therefore is only used if cargo is absent from the user's PATH.
+	fi && \
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		export CARGO_HOME="$(CARGOTMP)"; \
 		export CARGO_BUILD_JOBS=2; \
@@ -32,6 +33,7 @@ $(STATLIB):
 		export PATH="$(PATH):$(HOME)/.cargo/bin" && \
 		cargo build --lib --manifest-path="$(CURDIR)/rust/Cargo.toml" --target-dir "$(TARGET_DIR)" --target="$(TARGET)" \
 			--profile="$(PRQLR_PROFILE)" --features="$(PRQLR_FEATURES)"
+
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf "$(CARGOTMP)" "$(VENDOR_DIR)" "$(LIBDIR)/build"; \
 	fi

--- a/src/Makevars
+++ b/src/Makevars
@@ -2,9 +2,10 @@ TARGET ?= $(shell export PATH="$(PATH):$(HOME)/.cargo/bin" && rustc -vV | grep h
 PRQLR_PROFILE ?= release
 PRQLR_FEATURES ?=
 
+LIBNAME = libprqlr.a
 TARGET_DIR = $(CURDIR)/rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/$(PRQLR_PROFILE)
-STATLIB = $(LIBDIR)/libprqlr.a
+STATLIB = $(LIBDIR)/$(LIBNAME)
 PKG_LIBS = -L$(LIBDIR) -lprqlr
 
 all: C_clean
@@ -15,9 +16,9 @@ CARGOTMP = $(CURDIR)/.cargo
 VENDOR_DIR = $(CURDIR)/rust/vendor
 
 $(STATLIB):
-	if [ -f "$(CURDIR)/../tools/lib" ]; then \
+	if [ -f "$(CURDIR)/../tools/$(LIBNAME)" ]; then \
 		mkdir -p "$(LIBDIR)" ; \
-		mv "$(CURDIR)/../tools/lib" "$(STATLIB)" ; \
+		mv "$(CURDIR)/../tools/$(LIBNAME)" "$(STATLIB)" ; \
 		exit 0; \
 	fi && \
 	if [ -f "$(CURDIR)/rust/vendor.tar.xz" ]; then \

--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,5 +1,0 @@
-# Rtools42 doesn't have the linker in the location that cargo expects, so we
-# need to overwrite it via configuration.
-CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
-
-include Makevars.win

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -2,10 +2,15 @@ TARGET ?= $(subst 64,x86_64,$(subst 32,i686,$(WIN)))-pc-windows-gnu
 PRQLR_PROFILE ?= release
 PRQLR_FEATURES ?=
 
+LIBNAME = libprqlr.a
 TARGET_DIR = $(CURDIR)/rust/target
 LIBDIR = $(TARGET_DIR)/$(TARGET)/$(PRQLR_PROFILE)
-STATLIB = $(LIBDIR)/libprqlr.a
+STATLIB = $(LIBDIR)/$(LIBNAME)
 PKG_LIBS = -L$(LIBDIR) -lprqlr -lws2_32 -ladvapi32 -luserenv -lbcrypt -lntdll
+
+# Rtools42 doesn't have the linker in the location that cargo expects, so we
+# need to overwrite it via configuration.
+CARGO_LINKER = x86_64-w64-mingw32.static.posix-gcc.exe
 
 all: C_clean
 
@@ -15,23 +20,26 @@ CARGOTMP = $(CURDIR)/.cargo
 VENDOR_DIR = $(CURDIR)/rust/vendor
 
 $(STATLIB):
-	if [ -f "$(CURDIR)/rust/vendor.tar.xz" ]; then \
-		mkdir -p "$(VENDOR_DIR)" && \
-		$(TAR) --extract --xz --file "$(CURDIR)/rust/vendor.tar.xz" -C "$(VENDOR_DIR)" && \
-		mkdir -p "$(CARGOTMP)" && \
-		cp "$(CURDIR)/rust/vendor-config.toml" "$(CARGOTMP)/config.toml"; \
-	fi
-
-	mkdir -p "$(TARGET_DIR)/libgcc_mock"
 	# `rustc` adds `-lgcc_eh` flags to the compiler, but Rtools' GCC doesn't have
 	# `libgcc_eh` due to the compilation settings. So, in order to please the
 	# compiler, we need to add empty `libgcc_eh` to the library search paths.
 	#
 	# For more details, please refer to
 	# https://github.com/r-windows/rtools-packages/blob/2407b23f1e0925bbb20a4162c963600105236318/mingw-w64-gcc/PKGBUILD#L313-L316
+	mkdir -p "$(TARGET_DIR)/libgcc_mock"
 	touch "$(TARGET_DIR)/libgcc_mock/libgcc_eh.a"
 
-	# CARGO_LINKER is provided in Makevars.ucrt for R >= 4.2
+	if [ -f "$(CURDIR)/../tools/$(LIBNAME)" ]; then \
+		mkdir -p "$(LIBDIR)" ; \
+		mv "$(CURDIR)/../tools/$(LIBNAME)" "$(STATLIB)" ; \
+		exit 0; \
+	fi && \
+	if [ -f "$(CURDIR)/rust/vendor.tar.xz" ]; then \
+		mkdir -p "$(VENDOR_DIR)" && \
+		$(TAR) --extract --xz --file "$(CURDIR)/rust/vendor.tar.xz" -C "$(VENDOR_DIR)" && \
+		mkdir -p "$(CARGOTMP)" && \
+		cp "$(CURDIR)/rust/vendor-config.toml" "$(CARGOTMP)/config.toml"; \
+	fi && \
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		export CARGO_HOME="$(CARGOTMP)"; \
 		export CARGO_BUILD_JOBS=2; \
@@ -40,6 +48,7 @@ $(STATLIB):
 		export LIBRARY_PATH="$${LIBRARY_PATH};$(TARGET_DIR)/libgcc_mock" && \
 		cargo build --lib --manifest-path="$(CURDIR)/rust/Cargo.toml" --target-dir "$(TARGET_DIR)" --target="$(TARGET)" \
 			--profile="$(PRQLR_PROFILE)" --features="$(PRQLR_FEATURES)"
+
 	if [ "$(NOT_CRAN)" != "true" ]; then \
 		rm -Rf "$(CARGOTMP)" "$(VENDOR_DIR)" "$(LIBDIR)/build"; \
 	fi


### PR DESCRIPTION
Also, remove the unnecessary `Makevars.ucrt` file. (The file was needed for R for Windows < 4.2)