### PR TITLE
chore: set lib version to the Cargo.toml and update LICENSE.note

### DIFF
--- a/LICENSE.note
+++ b/LICENSE.note
@@ -44,7 +44,7 @@ License:     Apache-2.0 OR MIT
 -------------------------------------------------------------
 
 Name:        anstyle
-Version:     1.0.3
+Version:     1.0.2
 Repository:  https://github.com/rust-cli/anstyle.git
 Authors:     anstyle authors
 License:     Apache-2.0 OR MIT
@@ -292,7 +292,7 @@ License:     MIT
 -------------------------------------------------------------
 
 Name:        libc
-Version:     0.2.148
+Version:     0.2.147
 Repository:  https://github.com/rust-lang/libc
 Authors:     The Rust Project Developers
 License:     Apache-2.0 OR MIT
@@ -300,7 +300,7 @@ License:     Apache-2.0 OR MIT
 -------------------------------------------------------------
 
 Name:        linux-raw-sys
-Version:     0.4.7
+Version:     0.4.5
 Repository:  https://github.com/sunfishcode/linux-raw-sys
 Authors:     Dan Gohman
 License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
@@ -316,7 +316,7 @@ License:     Apache-2.0 OR MIT
 -------------------------------------------------------------
 
 Name:        memchr
-Version:     2.6.3
+Version:     2.6.1
 Repository:  https://github.com/BurntSushi/memchr
 Authors:     Andrew Gallant, bluss
 License:     MIT OR Unlicense
@@ -348,7 +348,7 @@ License:     MIT
 -------------------------------------------------------------
 
 Name:        object
-Version:     0.32.1
+Version:     0.32.0
 Repository:  https://github.com/gimli-rs/object
 Authors:     object authors
 License:     Apache-2.0 OR MIT
@@ -372,7 +372,7 @@ License:     Apache-2.0 OR MIT
 -------------------------------------------------------------
 
 Name:        proc-macro2
-Version:     1.0.67
+Version:     1.0.66
 Repository:  https://github.com/dtolnay/proc-macro2
 Authors:     David Tolnay, Alex Crichton
 License:     Apache-2.0 OR MIT
@@ -452,7 +452,7 @@ License:     Apache-2.0 OR MIT
 -------------------------------------------------------------
 
 Name:        rustix
-Version:     0.38.13
+Version:     0.38.10
 Repository:  https://github.com/bytecodealliance/rustix
 Authors:     Dan Gohman, Jakub Konka
 License:     Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT
@@ -500,7 +500,7 @@ License:     Apache-2.0 OR MIT
 -------------------------------------------------------------
 
 Name:        serde_json
-Version:     1.0.107
+Version:     1.0.105
 Repository:  https://github.com/serde-rs/json
 Authors:     Erick Tryzelaar, David Tolnay
 License:     Apache-2.0 OR MIT
@@ -556,7 +556,7 @@ License:     Apache-2.0 OR MIT
 -------------------------------------------------------------
 
 Name:        syn
-Version:     2.0.36
+Version:     2.0.29
 Repository:  https://github.com/dtolnay/syn
 Authors:     David Tolnay
 License:     Apache-2.0 OR MIT
@@ -564,7 +564,7 @@ License:     Apache-2.0 OR MIT
 -------------------------------------------------------------
 
 Name:        unicode-ident
-Version:     1.0.12
+Version:     1.0.11
 Repository:  https://github.com/dtolnay/unicode-ident
 Authors:     David Tolnay
 License:     (MIT OR Apache-2.0) AND Unicode-DFS-2016

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "prqlr"
-version = "0.1.0"
+version = "0.9.0"
 dependencies = [
  "anstream",
  "extendr-api",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "prqlr"
-version = "0.1.0"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.65"
+publish = false
 
 [lib]
 crate-type = ['staticlib']


### PR DESCRIPTION
Related to #189

From now on, I will synchronize the Rust library version with prql-compiler.

This PR also includes updates to LICENSE.note, which had not been updated in #180.