### PR TITLE
ci: should stop if the tests are failed

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -121,12 +121,12 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, any::devtools
+          extra-packages: any::rcmdcheck, any::testthat, any::remotes
           needs: check
 
       - name: Install with pre-built binary
         if: env.TEST_BIN_LIB == 'true'
         shell: Rscript {0}
         run: |
-          remotes::install_local()
-          devtools::test()
+          remotes::install_local(force = TRUE)
+          testthat::test_dir("tests")

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -146,7 +146,7 @@ jobs:
         shell: Rscript {0}
         run: |
           devtools::load_all()
-          devtools::test()
+          testthat::test_dir("tests")
 
   release:
     needs:


### PR DESCRIPTION
`devtools::test`'s exit code always 0 (r-lib/testthat#515). So I shoud use `testthat::test("tests")` here instead.

And, `force=TRUE` should be set to `remotes::install_local`.