### PR TITLE
ci: fix some Rust cache steps on some GitHub Actions workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -70,17 +70,6 @@ jobs:
           use-public-rspm: true
           Ncpus: "2"
 
-      - name: check target
-        id: check-target
-        shell: bash
-        run: |
-          echo "target=$(rustc -vV | grep host | cut -d' ' -f2)" >>"$GITHUB_OUTPUT"
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "src/rust -> target"
-          shared-key: ${{ steps.check-target.outputs.target }}
-
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,8 +68,18 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
-          rtools-version: ${{ matrix.config.rtools-version }}
           Ncpus: "2"
+
+      - name: check target
+        id: check-target
+        shell: bash
+        run: |
+          echo "target=$(rustc -vV | grep host | cut -d' ' -f2)" >>"$GITHUB_OUTPUT"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "src/rust -> target"
+          shared-key: ${{ steps.check-target.outputs.target }}
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -44,6 +44,11 @@ jobs:
           use-public-rspm: true
           Ncpus: "2"
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "src/rust -> target"
+          shared-key: x86_64-unknown-linux-gnu
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgdown, local::.

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "src/rust -> target"
-          shared-key: build
+          shared-key: ${{ matrix.target }}
 
       - name: prep for musl
         if: runner.os == 'Linux'


### PR DESCRIPTION
Enable Rust cache on release-lib workflow and pkgdown workflow.