### PR TITLE
ci: fix the release job to use actions/download-artifact@v4

### DIFF
--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -176,9 +176,29 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: libs
+          name: libs-x86_64-unknown-linux-musl
+          path: libs
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: libs-aarch64-unknown-linux-musl
+          path: libs
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: libs-x86_64-apple-darwin
+          path: libs
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: libs-aarch64-apple-darwin
+          path: libs
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: libs-x86_64-pc-windows-gnu
           path: libs
 
       - name: create checksums


### PR DESCRIPTION
A follow up for #236

I forgot to update the release job.